### PR TITLE
Adding  funtionality to allow the third-party application to have direct access to Lucene

### DIFF
--- a/src/main/java/org/crosswire/jsword/index/IndexManager.java
+++ b/src/main/java/org/crosswire/jsword/index/IndexManager.java
@@ -66,4 +66,9 @@ public interface IndexManager {
      * you created.
      */
     void deleteIndex(Book book) throws BookException;
+
+    /**
+     * Close all indexes associated with this Index Manager
+     */
+    void closeAllIndexes();
 }

--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndexManager.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndexManager.java
@@ -22,9 +22,7 @@
 package org.crosswire.jsword.index.lucene;
 
 import java.io.File;
-import java.io.FileDescriptor;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,6 +84,16 @@ public class LuceneIndexManager implements IndexManager {
         } catch (IOException ex) {
             // TRANSLATOR: Common error condition: Some error happened while opening a search index.
             throw new BookException(JSMsg.gettext("Failed to initialize Lucene search engine."), ex);
+        }
+    }
+    
+    /*
+     *     @Override(non-Javadoc)
+     * @see org.crosswire.jsword.index.IndexManager#closeAllIndexes()
+     */
+    public void closeAllIndexes() {
+        for(Index index : INDEXES.values()) {
+            index.close();
         }
     }
 


### PR DESCRIPTION
Removing Activable as per the refactor work in OpenFileState... For 2 reasons:
- There was a way through the code (I haven't worked out yet) which caused NullPointer in activate, where the boolean value got out of sync with the nulled out resources on deactivate
- Performance analysis showed that 15% of time in quick fire requests was spent opening up the index searcher (it seems the Lucene doc supports this view: "For performance reasons, if your index is unchanging, you should share a single IndexSearcher instance across multiple searches instead of creating a new one per-search" http://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/api/core/org/apache/lucene/search/IndexSearcher.html) And elsewhere it says that opening up a IndexReader is an expensive operation. 
- Changed the TermVector setting for Strong numbers to allow us to get frequencies out
- Exposing the LuceneSearcher to allow people to do their own complicated tasks on top of the functionality that JSword provides.
