### PR TITLE
JS-249 QA Cleanup - Checkstyle and JavaDoc

### DIFF
--- a/JSwordDictionary.txt
+++ b/JSwordDictionary.txt
@@ -200,3 +200,5 @@ enum
 rev
 prequel
 zip
+chris
+burrell

--- a/src/main/java/org/crosswire/common/icu/NumberShaper.java
+++ b/src/main/java/org/crosswire/common/icu/NumberShaper.java
@@ -46,9 +46,11 @@ import org.crosswire.jsword.internationalisation.LocaleProviderManager;
  * change that. So to get around this we mark the ':' as a right-to-left
  * character.
  * </p>
+ * <p>
+ * See also: com.ibm.icu.text.ArabicShaping
+ * </p>
  * 
  * @see java.awt.font.NumericShaper
- * @see com.ibm.icu.text.ArabicShaping
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's authors.
  * @author DM Smith [dmsmith555 at yahoo dot com]

--- a/src/main/java/org/crosswire/common/progress/Job.java
+++ b/src/main/java/org/crosswire/common/progress/Job.java
@@ -48,7 +48,7 @@ public final class Job implements Progress {
      * Create a new Job. This will automatically fire a workProgressed event to
      * all WorkListeners, with the work property of this job set to 0.
      * 
-     * @param description
+     * @param jobName
      *            Short description of this job
      * @param worker
      *            Optional thread to use in request to stop worker
@@ -209,7 +209,7 @@ public final class Job implements Progress {
 
             int oldPercent = percent;
             // use long in arithmetic to avoid integer overflow 
-            percent = (int)(100L * workUnits / totalUnits);
+            percent = (int) (100L * workUnits / totalUnits);
             if (oldPercent == percent) {
                 return;
             }

--- a/src/main/java/org/crosswire/common/util/Countries.java
+++ b/src/main/java/org/crosswire/common/util/Countries.java
@@ -109,7 +109,7 @@ public class Countries {
     private static ResourceBundle getLocalisedCountries() {
         return ResourceBundle.getBundle("iso3166", LocaleProviderManager.getLocale(), CWClassLoader.instance());
     }
-    
+
     public static final String DEFAULT_COUNTRY_CODE = "US";
     private static final String UNKNOWN_COUNTRY_CODE = "XX";
 }

--- a/src/main/java/org/crosswire/common/util/IOUtil.java
+++ b/src/main/java/org/crosswire/common/util/IOUtil.java
@@ -79,15 +79,15 @@ public final class IOUtil {
                         throw new MalformedURLException(JSMsg.gettext("The URL {0} could not be created as a directory.", parentDir.toString()));
                     }
                 }
-                
+
                 // write entryFile from zip to filesystem but avoid writing dir entries out as files
                 if (!entry.isDirectory()) {
 
                     URI child = NetUtil.getURI(entryFile);
-    
+
                     OutputStream dataOut = NetUtil.getOutputStream(child);
                     InputStream dataIn = zf.getInputStream(entry);
-    
+
                     while (true) {
                         int count = dataIn.read(dbuf);
                         if (count == -1) {
@@ -95,7 +95,7 @@ public final class IOUtil {
                         }
                         dataOut.write(dbuf, 0, count);
                     }
-    
+
                     dataOut.close();
                 }
             }
@@ -136,8 +136,6 @@ public final class IOUtil {
         }
     }
 
-        
-    
     /**
      * The log stream
      */

--- a/src/main/java/org/crosswire/common/util/Languages.java
+++ b/src/main/java/org/crosswire/common/util/Languages.java
@@ -135,10 +135,10 @@ public class Languages {
     private static ResourceBundle getLocalisedCommonLanguages() {
         Locale locale = LocaleProviderManager.getLocale();
         ResourceBundle langs = localisedCommonLanguages.get(locale);
-        if(langs == null) {
-            synchronized(Languages.class) {
+        if (langs == null) {
+            synchronized (Languages.class) {
                 langs = localisedCommonLanguages.get(locale);
-                if(langs == null) {
+                if (langs == null) {
                     langs = initLanguages(locale);
                     localisedCommonLanguages.put(locale, langs);
                 }
@@ -146,7 +146,7 @@ public class Languages {
         }
         return langs;
     }
-    
+
     private static ResourceBundle initLanguages(Locale locale) {
         try {
             return ResourceBundle.getBundle("iso639", locale, CWClassLoader.instance());
@@ -159,11 +159,9 @@ public class Languages {
         return ResourceBundle.getBundle("iso639full", locale, CWClassLoader.instance());
     }
 
-    
     public static final String DEFAULT_LANG_CODE = "en";
     private static final String UNKNOWN_LANG_CODE = "und";
     private static final Logger log = Logger.getLogger(Books.class);
-    
     private static/* final */ResourceBundle allLangs;
     private static Map<Locale, ResourceBundle> localisedCommonLanguages = new HashMap<Locale, ResourceBundle>();
 }

--- a/src/main/java/org/crosswire/common/util/Logger.java
+++ b/src/main/java/org/crosswire/common/util/Logger.java
@@ -213,7 +213,7 @@ public final class Logger {
     }
 
     /**
-     * Create a logger for the class. Wrapped by {@link #java.util.logging.Logger.getLogger(String)}.
+     * Create a logger for the class. Wrapped by {@link java.util.logging.Logger#getLogger(String)}.
      */
     private <T> Logger(Class<T> id, boolean showLocation) {
         this.logger = java.util.logging.Logger.getLogger(id.getName());
@@ -222,18 +222,17 @@ public final class Logger {
 
     // Private method to infer the caller's class and method names
     private void doLogging(Level theLevel, String message, Throwable th) {
-        //now check whether we should do any work: if 
-        if(!shouldLog(theLevel) ) {
+        // now check whether we should do any work
+        if (!shouldLog(theLevel)) {
             return;
         }
-        
-        
+
         LogRecord logRecord = new LogRecord(theLevel, message);
         logRecord.setLoggerName(logger.getName());
         logRecord.setSourceClassName(CallContext.getCallingClass(1).getName());
         logRecord.setThrown(th);
 
-        if (showLocation && (showLocationForInfoDebugTrace || theLevel.intValue() > Level.INFO.intValue()) ) {
+        if (showLocation && (showLocationForInfoDebugTrace || theLevel.intValue() > Level.INFO.intValue())) {
             String methodName = null;
             int lineNumber = -1;
 
@@ -330,7 +329,7 @@ public final class Logger {
             Logger.level = null;
         }
     }
-    
+
     /**
      * Sets the show location for debug and trace.
      *
@@ -339,13 +338,13 @@ public final class Logger {
     public static void setShowLocationForInfoDebugTrace(boolean enabled) {
         showLocationForInfoDebugTrace = enabled;
     }
-    
+
     private static final String ROOT_LOGGER = "";
     private static final String CLASS_NAME = Logger.class.getName();
     private static volatile boolean established;
     private static volatile Level level;
     private static boolean showLocationForInfoDebugTrace = true;
-    
+
     /**
      * The actual logger.
      */

--- a/src/main/java/org/crosswire/common/util/MsgBase.java
+++ b/src/main/java/org/crosswire/common/util/MsgBase.java
@@ -33,8 +33,7 @@ import org.crosswire.jsword.internationalisation.LocaleProviderManager;
 
 /**
  * A base class for implementing type safe internationalization (i18n) that is
- * easy for most cases. See {@link org.crosswire.common.util.Msg} for an example
- * of how to inherit from here.
+ * easy for most cases.
  *
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's authors.
@@ -85,20 +84,20 @@ public class MsgBase {
         String shortClassName = ClassUtil.getShortClassName(className);
 
         Locale currentUserLocale = LocaleProviderManager.getLocale();
-        Map<String,ResourceBundle> localisedResourceMap = getLazyLocalisedResourceMap(currentUserLocale);
-        
+        Map<String, ResourceBundle> localisedResourceMap = getLazyLocalisedResourceMap(currentUserLocale);
+
         ResourceBundle resourceBundle = localisedResourceMap.get(className);
-        if(resourceBundle == null) {
+        if (resourceBundle == null) {
             resourceBundle = getResourceBundleForClass(implementingClass, className, shortClassName, currentUserLocale, localisedResourceMap);
         }
 
-        //if for some reason, we are still looking at a null, then we can only do our best, which is to return the English Locale.
-        if(resourceBundle == null) {
+        // if for some reason, we are still looking at a null, then we can only do our best, which is to return the English Locale.
+        if (resourceBundle == null) {
             resourceBundle  = getResourceBundleForClass(implementingClass, className, shortClassName, Locale.ENGLISH, localisedResourceMap);
         }
-        
+
         //if we're still looking at a null, there is definitely nothing else we can do, so throw an exception
-        if(resourceBundle == null) {
+        if (resourceBundle == null) {
             log.error("Missing resources: Locale=" + currentUserLocale.toString() + " class=" + className);
             throw new MissingResourceException("Unable to find the language resources.", className, shortClassName);
         }
@@ -115,12 +114,11 @@ public class MsgBase {
      * @param localisedResourceMap the localised resource map
      * @return the resource bundle for class
      */
-    private ResourceBundle getResourceBundleForClass(Class<? extends MsgBase> implementingClass, String className, String shortClassName, Locale currentUserLocale,
-            Map<String,ResourceBundle> localisedResourceMap) {
+    private ResourceBundle getResourceBundleForClass(Class<? extends MsgBase> implementingClass, String className, String shortClassName, Locale currentUserLocale, Map<String, ResourceBundle> localisedResourceMap) {
         ResourceBundle resourceBundle;
         synchronized (getClass()) {
             resourceBundle = localisedResourceMap.get(className);
-            if(resourceBundle == null) {
+            if (resourceBundle == null) {
                 try {
                     resourceBundle = ResourceBundle.getBundle(shortClassName, currentUserLocale, CWClassLoader.instance(implementingClass));
                     localisedResourceMap.put(className, resourceBundle);
@@ -138,12 +136,12 @@ public class MsgBase {
      * @param currentUserLocale the current user locale
      * @return the lazy localised resource map
      */
-    private Map<String,ResourceBundle> getLazyLocalisedResourceMap(Locale currentUserLocale) {
-        Map<String,ResourceBundle> localisedResourceMap = localeToResourceMap.get(currentUserLocale);
-        if(localisedResourceMap == null) {
-            synchronized(MsgBase.class) {
+    private Map<String, ResourceBundle> getLazyLocalisedResourceMap(Locale currentUserLocale) {
+        Map<String, ResourceBundle> localisedResourceMap = localeToResourceMap.get(currentUserLocale);
+        if (localisedResourceMap == null) {
+            synchronized (MsgBase.class) {
                 localisedResourceMap = localeToResourceMap.get(currentUserLocale);
-                if(localisedResourceMap == null) {
+                if (localisedResourceMap == null) {
                     localisedResourceMap = new HashMap<String, ResourceBundle>(512);
                     localeToResourceMap.put(currentUserLocale, localisedResourceMap);
                 }
@@ -151,8 +149,8 @@ public class MsgBase {
         }
         return localisedResourceMap;
     }
-    
-    private static Map<Locale, Map<String,ResourceBundle>> localeToResourceMap = new HashMap<Locale, Map<String, ResourceBundle>>();
+
+    private static Map<Locale, Map<String, ResourceBundle>> localeToResourceMap = new HashMap<Locale, Map<String, ResourceBundle>>();
 
     /** Internationalize numbers */
     private NumberShaper shaper;

--- a/src/main/java/org/crosswire/common/util/PropertyMap.java
+++ b/src/main/java/org/crosswire/common/util/PropertyMap.java
@@ -38,13 +38,6 @@ import java.util.Properties;
  *      The copyright to this program is held by it's authors.
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
-/**
- *
- *
- * @see gnu.lgpl.License for license details.<br>
- *      The copyright to this program is held by it's authors.
- * @author DM Smith [dmsmith555 at yahoo dot com]
- */
 public class PropertyMap extends LinkedHashMap<String, String> {
     /**
      * Creates an empty property list with no default values.
@@ -97,14 +90,14 @@ public class PropertyMap extends LinkedHashMap<String, String> {
     }
 
     /**
-     * Merely a call to {@link #put(String, String)}, provided as
+     * Merely a call to <code>put(String, String)</code>, provided as
      * a simple way to migrate from {@link java.lang.Properties}.
      *
      * @param key the key to be placed into this property list.
      * @param value the value corresponding to <tt>key</tt>.
      * @return     the previous value of the specified key in this property
      *             list, or <code>null</code> if it did not have one.
-     * @deprecated use {@link #put(String, String)} instead
+     * @deprecated use <code>put(String, String)</code> instead.
      */
     @Deprecated
     public String setProperty(String key, String value) {
@@ -117,7 +110,7 @@ public class PropertyMap extends LinkedHashMap<String, String> {
      * 
      * @param key the lookup key
      * @return  the value in this property list with the specified key value.
-     * @deprecated use {@link @get(String)} instead
+     * @deprecated use {@link #get(String)} instead
      */
     @Deprecated
     public String getProperty(String key) {

--- a/src/main/java/org/crosswire/jsword/book/Book.java
+++ b/src/main/java/org/crosswire/jsword/book/Book.java
@@ -119,7 +119,6 @@ public interface Book extends Activatable, Comparable<Book> {
      */
     boolean contains(Key key);
 
-    
     /**
      * Returns the raw text that getData(Key key) builds into OSIS.
      * 
@@ -130,7 +129,7 @@ public interface Book extends Activatable, Comparable<Book> {
      *             If anything goes wrong with this method
      */
     String getRawText(Key key) throws BookException;
-    
+
     /**
      * A Book is writable if the file system allows the underlying files to be
      * opened for writing and if the driver for the book allows writing.

--- a/src/main/java/org/crosswire/jsword/book/BookData.java
+++ b/src/main/java/org/crosswire/jsword/book/BookData.java
@@ -32,7 +32,6 @@ import org.crosswire.common.util.Language;
 import org.crosswire.common.xml.JDOMSAXEventProvider;
 import org.crosswire.common.xml.SAXEventProvider;
 import org.crosswire.jsword.passage.Key;
-import org.jdom.Attribute;
 import org.jdom.Content;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -220,11 +219,11 @@ public class BookData implements BookProvider {
                     cell = OSISUtil.factory().createCell();
                     Language lang = (Language) book.getProperty(BookMetaData.KEY_XML_LANG);
                     cell.setAttribute(OSISUtil.OSIS_ATTR_LANG, lang.getCode(), Namespace.XML_NAMESPACE);
-                    
+
                     row.addContent(cell);
 
                     StringBuilder newText = new StringBuilder(doDiffs ? 32 : 0);
-                    
+
                     if (iters[i].hasNext()) {
                         List<Content> contents = new ArrayList<Content>(1);
 
@@ -232,14 +231,14 @@ public class BookData implements BookProvider {
                             content = iters[i].next();
                             contents.add(content);
                             addText(doDiffs, newText, content);
-                        } while(!isNextVerse(content));
-                        
+                        } while (!isNextVerse(content));
+
                         if (doDiffs) {
                             String thisText = newText.toString();
-                            if(unaccenter != null) {
+                            if (unaccenter != null) {
                                 thisText = unaccenter.unaccent(thisText);
                             }
-                            
+
                             if (i > 0 && showDiffs[i - 1]) {
                                 List<Difference> diffs = new Diff(lastText, thisText, false).compare();
                                 DiffCleanup.cleanupSemantic(diffs);
@@ -274,20 +273,20 @@ public class BookData implements BookProvider {
     }
 
     private boolean isNextVerse(Content content) {
-        if(content instanceof Element) {
+        if (content instanceof Element) {
             return OSISUtil.OSIS_ELEMENT_VERSE.equals(((Element) content).getName());
         }
-        
+
         return false;
     }
 
     private void addText(boolean doDiffs, StringBuilder newText, Content content) {
-        if(doDiffs) {
-            //if we already have content, let's add a space to avoid chaining words together
-            if(newText.length() != 0) {
+        if (doDiffs) {
+            // if we already have content, let's add a space to avoid chaining words together
+            if (newText.length() != 0) {
                 newText.append(' ');
             }
-            
+
             if (content instanceof Element) {
                 newText.append(OSISUtil.getCanonicalText((Element) content));
             } else if (content instanceof Text) {
@@ -295,8 +294,7 @@ public class BookData implements BookProvider {
             }
         }
     }
-    
-    
+
     /**
      * @param unaccenter the unaccenter to set
      */
@@ -328,6 +326,6 @@ public class BookData implements BookProvider {
      * Just the element
      */
     private Element fragment;
-    
+
     private UnAccenter unaccenter;
 }

--- a/src/main/java/org/crosswire/jsword/book/OSISUtil.java
+++ b/src/main/java/org/crosswire/jsword/book/OSISUtil.java
@@ -718,7 +718,6 @@ public final class OSISUtil {
      * concatenates strong and morphology information together
      * @param root
      * @param includeMorphology
-     * @param separator
      * @return root of the element
      */
     public static String getLexicalInformation(Element root, boolean includeMorphology) {
@@ -734,17 +733,17 @@ public final class OSISUtil {
                     if (buffer.length() > 0) {
                         buffer.append(' ');
                     }
-                    
-                    if(includeMorphology) {
+
+                    if (includeMorphology) {
                         //if including morphology, we want 1 big field, separated with '@'
                         strongsNum = strongsNum.replace(SPACE_SEPARATOR, MORPH_INFO_SEPARATOR);
                     }
                     buffer.append(strongsNum);
-                    
-                    if(includeMorphology) {
+
+                    if (includeMorphology) {
                         //also include morphology if available
                         String morph = ele.getAttributeValue(OSISUtil.ATTRIBUTE_W_MORPH);
-                        if(morph != null && morph.length() != 0) {
+                        if (morph != null && morph.length() != 0) {
                             buffer.append(MORPH_INFO_SEPARATOR);
                             buffer.append(morph.replace(SPACE_SEPARATOR, MORPH_INFO_SEPARATOR));
                         }
@@ -756,7 +755,6 @@ public final class OSISUtil {
         return buffer.toString().trim();
     }
 
-    
     /**
      * A space separate string containing osisID from the reference element.
      * 
@@ -814,7 +812,7 @@ public final class OSISUtil {
 
         for (Content content : getDeepContent(root, OSISUtil.OSIS_ELEMENT_TITLE)) {
             Element ele = (Element) content;
-            
+
             if (buffer.length() > 0) {
                 buffer.append(' ');
             }

--- a/src/main/java/org/crosswire/jsword/book/basic/AbstractBook.java
+++ b/src/main/java/org/crosswire/jsword/book/basic/AbstractBook.java
@@ -357,7 +357,7 @@ public abstract class AbstractBook implements Book {
         }
     }
 
-    abstract protected List<Content> getOsis(Key key, RawTextToXmlProcessor noOpRawTextProcessor) throws BookException;
+    protected abstract List<Content> getOsis(Key key, RawTextToXmlProcessor noOpRawTextProcessor) throws BookException;
 
     /*
      * (non-Javadoc)

--- a/src/main/java/org/crosswire/jsword/book/basic/AbstractPassageBook.java
+++ b/src/main/java/org/crosswire/jsword/book/basic/AbstractPassageBook.java
@@ -52,7 +52,7 @@ import org.jdom.Element;
  * @author Joe Walker [joe at eireneh dot com]
  */
 public abstract class AbstractPassageBook extends AbstractBook {
-    
+
     public AbstractPassageBook(BookMetaData bmd) {
         super(bmd);
         this.versification = (String) bmd.getProperty(BookMetaData.KEY_VERSIFICATION);
@@ -70,7 +70,6 @@ public abstract class AbstractPassageBook extends AbstractBook {
         Passage ref = KeyUtil.getPassage(key, getVersification());
         final boolean showTitles = ref.hasRanges(RestrictionType.CHAPTER) || !allowEmpty;
 
-        
         RawTextToXmlProcessor processor = new RawTextToXmlProcessor() {
             public void preRange(VerseRange range, List<Content> partialDom) {
                 if (showTitles) {
@@ -97,7 +96,6 @@ public abstract class AbstractPassageBook extends AbstractBook {
         return getOsis(ref, processor).iterator();
     }
 
-    
     /**
      * Add the OSIS elements to the div element. Note, this assumes that the
      * data is fully marked up.
@@ -220,12 +218,12 @@ public abstract class AbstractPassageBook extends AbstractBook {
     }
 
     public Versification getVersification() {
-        if(this.versificationSystem == null) {
-            this.versificationSystem = Versifications.instance().getVersification((String) getBookMetaData().getProperty(BookMetaData.KEY_VERSIFICATION)); 
+        if (this.versificationSystem == null) {
+            this.versificationSystem = Versifications.instance().getVersification((String) getBookMetaData().getProperty(BookMetaData.KEY_VERSIFICATION));
         }
         return versificationSystem;
     }
-    
+
     /**
      * A cached representation of the global key list.
      */
@@ -240,7 +238,7 @@ public abstract class AbstractPassageBook extends AbstractBook {
      * Versification system, created lazily, so use getter
      */
     private Versification versificationSystem;
-    
+
     /**
      * Our key manager
      */

--- a/src/main/java/org/crosswire/jsword/book/filter/osis/OSISFilter.java
+++ b/src/main/java/org/crosswire/jsword/book/filter/osis/OSISFilter.java
@@ -130,7 +130,7 @@ public class OSISFilter implements Filter {
      */
     private Element parse(String plain) throws JDOMException, IOException {
         SAXBuilder builder = saxBuilders.poll();
-        if(builder == null) {
+        if (builder == null) {
             //then we have no sax builders available, so let's create a new one and store
             builder = new SAXBuilder();
             builder.setFastReconfigure(true);
@@ -140,19 +140,19 @@ public class OSISFilter implements Filter {
         StringReader in = null;
         Element div;
         try {
-            in = new StringReader("<div>" + plain + "</div>"); 
+            in = new StringReader("<div>" + plain + "</div>");
             InputSource is = new InputSource(in);
             Document doc = builder.build(is);
             div = doc.getRootElement();
         } finally {
-            if(in != null) {
+            if (in != null) {
                 in.close();
             }
         }
 
         //return builder to queue, or offer a new one. Ignore return value as we don't care whether the builder is going to be re-used
         saxBuilders.offer(builder);
-        
+
         return div;
     }
 

--- a/src/main/java/org/crosswire/jsword/book/readings/ReadingsBook.java
+++ b/src/main/java/org/crosswire/jsword/book/readings/ReadingsBook.java
@@ -113,7 +113,7 @@ public class ReadingsBook extends AbstractBook implements PreferredKey {
 
         global = new SetKeyList(hash.keySet(), getName());
     }
-    
+
     /* (non-Javadoc)
      * @see org.crosswire.jsword.passage.PreferredKey#getPreferred()
      */
@@ -174,8 +174,6 @@ public class ReadingsBook extends AbstractBook implements PreferredKey {
         return false;
     }
 
-    
-
     /** Returns an empty string
      * (non-Javadoc)
      * @see org.crosswire.jsword.book.Book#getRawText(org.crosswire.jsword.passage.Key)
@@ -183,7 +181,7 @@ public class ReadingsBook extends AbstractBook implements PreferredKey {
     public String getRawText(Key key) throws BookException {
         return "";
     }
-    
+
     /**
      * Returns an empty list
      */

--- a/src/main/java/org/crosswire/jsword/book/study/StrongsMapSet.java
+++ b/src/main/java/org/crosswire/jsword/book/study/StrongsMapSet.java
@@ -53,7 +53,6 @@ public class StrongsMapSet {
      *            the Strong's Number
      * @param representation
      *            a way the Strong's number is represented.
-     * @param locale the locale of the book being indexed
      */
     public void add(String strongsNumber, String representation) {
         Set<String> reps = map.get(strongsNumber);

--- a/src/main/java/org/crosswire/jsword/book/study/StrongsNumber.java
+++ b/src/main/java/org/crosswire/jsword/book/study/StrongsNumber.java
@@ -25,8 +25,6 @@ import java.text.DecimalFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.crosswire.jsword.book.BookException;
-
 /**
  * A Strong's Number is either Greek or Hebrew, where the actual numbers for
  * each start at 1. This class can parse Strong's Numbers that begin with G, g,
@@ -246,7 +244,7 @@ public class StrongsNumber {
         // Get the number after the G or H
         try {
             strongsNumber = Short.parseShort(m.group(2));
-        } catch(NumberFormatException e) {
+        } catch (NumberFormatException e) {
             strongsNumber = 0; // An invalid Strong's Number
             return false;
         }

--- a/src/main/java/org/crosswire/jsword/book/sword/AbstractBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/AbstractBackend.java
@@ -53,7 +53,7 @@ import org.jdom.Content;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public abstract class AbstractBackend<T extends OpenFileState> implements StatefulFileBackedBackend<T> {
- 
+
     /**
      * Default constructor for the sake of serialization.
      */
@@ -199,9 +199,8 @@ public abstract class AbstractBackend<T extends OpenFileState> implements Statef
     private Verse readPassageOsis(Key key, RawTextToXmlProcessor processor, final List<Content> content, T openFileState) throws BookException {
         Verse currentVerse = null;
         try {
-            
-            
-            final Passage ref = (key instanceof Passage ? (Passage) key : KeyUtil.getPassage(key, getVersification()));
+
+            final Passage ref = key instanceof Passage ? (Passage) key : KeyUtil.getPassage(key, getVersification());
             final Iterator<Key> rit = ref.rangeIterator(RestrictionType.CHAPTER);
             while (rit.hasNext()) {
                 VerseRange range = (VerseRange) rit.next();
@@ -282,12 +281,12 @@ public abstract class AbstractBackend<T extends OpenFileState> implements Statef
     }
 
     public Versification getVersification() {
-        if(this.versificationSystem == null) {
-            this.versificationSystem = Versifications.instance().getVersification((String) getBookMetaData().getProperty(BookMetaData.KEY_VERSIFICATION)); 
+        if (this.versificationSystem == null) {
+            this.versificationSystem = Versifications.instance().getVersification((String) getBookMetaData().getProperty(BookMetaData.KEY_VERSIFICATION));
         }
         return versificationSystem;
     }
-    
+
     private SwordBookMetaData bmd;
     private Versification versificationSystem;
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/RawBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/RawBackend.java
@@ -45,7 +45,7 @@ import org.crosswire.jsword.versification.system.Versifications;
  * @author Joe Walker [joe at eireneh dot com]
  */
 public class RawBackend<T extends RawBackendState> extends AbstractBackend<RawBackendState> {
-   
+
     /**
      * Simple ctor
      */
@@ -94,12 +94,11 @@ public class RawBackend<T extends RawBackendState> extends AbstractBackend<RawBa
     public T initState() throws BookException {
         return (T) OpenFileStateManager.getRawBackendState(getBookMetaData());
     }
-    
+
     public String getRawText(RawBackendState state, Key key) throws IOException {
         return readRawContent(state, key, key.getName());
     }
-    
-    
+
     /* (non-Javadoc)
      * @see org.crosswire.jsword.book.sword.AbstractBackend#getRawText(org.crosswire.jsword.passage.Key)
      */
@@ -107,7 +106,7 @@ public class RawBackend<T extends RawBackendState> extends AbstractBackend<RawBa
             String v11nName = getBookMetaData().getProperty(ConfigEntryType.VERSIFICATION).toString();
             Versification v11n = Versifications.instance().getVersification(v11nName);
             Verse verse = KeyUtil.getVerse(key, v11n);
-            
+
             int index = v11n.getOrdinal(verse);
 
             Testament testament = v11n.getTestament(index);

--- a/src/main/java/org/crosswire/jsword/book/sword/RawFileBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/RawFileBackend.java
@@ -78,7 +78,7 @@ public class RawFileBackend extends RawBackend<RawFileBackendState> {
     public RawFileBackendState initState() throws BookException {
         return OpenFileStateManager.getRawFileBackendState(getBookMetaData());
     }
-    
+
     /* (non-Javadoc)
      * @see org.crosswire.jsword.book.sword.RawBackend#getEntry(java.lang.String, org.crosswire.jsword.versification.Testament, long)
      */

--- a/src/main/java/org/crosswire/jsword/book/sword/RawLDBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/RawLDBackend.java
@@ -36,7 +36,6 @@ import java.util.regex.Pattern;
 
 import org.crosswire.common.icu.DateFormatter;
 import org.crosswire.common.util.IOUtil;
-import org.crosswire.common.util.Logger;
 import org.crosswire.common.util.StringUtil;
 import org.crosswire.jsword.JSMsg;
 import org.crosswire.jsword.book.BookCategory;
@@ -370,8 +369,6 @@ public class RawLDBackend<T extends RawLDBackendState> extends AbstractKeyBacken
         return keytitle;
     }
 
-
-
     /**
      * A means to normalize Strong's Numbers.
      */
@@ -386,7 +383,6 @@ public class RawLDBackend<T extends RawLDBackendState> extends AbstractKeyBacken
         return new DecimalFormat("0000");
     }
 
-    
     /**
      * Serialization support.
      * 
@@ -398,7 +394,6 @@ public class RawLDBackend<T extends RawLDBackendState> extends AbstractKeyBacken
         is.defaultReadObject();
     }
 
-    
     /**
      * Date formatter
      */
@@ -430,9 +425,4 @@ public class RawLDBackend<T extends RawLDBackendState> extends AbstractKeyBacken
      * How many bytes in the offset pointers in the index
      */
     private static final int OFFSETSIZE = 4;
-
-    /**
-     * The log stream
-     */
-    private static final Logger log = Logger.getLogger(RawLDBackend.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/StatefulFileBackedBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/StatefulFileBackedBackend.java
@@ -1,3 +1,23 @@
+/**
+ * Distribution License:
+ * JSword is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License, version 2.1 as published by
+ * the Free Software Foundation. This program is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The License is available on the internet at:
+ *       http://www.gnu.org/copyleft/lgpl.html
+ * or by writing to:
+ *      Free Software Foundation, Inc.
+ *      59 Temple Place - Suite 330
+ *      Boston, MA 02111-1307, USA
+ *
+ * Copyright: 2012
+ *     The copyright to this program is held by it's authors.
+ *
+ */
 package org.crosswire.jsword.book.sword;
 
 import java.io.IOException;
@@ -30,7 +50,7 @@ public interface StatefulFileBackedBackend<T extends OpenFileState> {
      * 
      * @param state
      *            the state object containing all the open random access files
-     * @param currentVerse
+     * @param key
      *            the verse that is sought
      * @param keyName
      *            the name of the current key
@@ -39,7 +59,7 @@ public interface StatefulFileBackedBackend<T extends OpenFileState> {
      *             something whent wrong when reading the verse
      */
      String readRawContent(T state, Key key, String keyName) throws BookException, IOException;
- 
+
      /**
       * Set the text allotted for the given verse
       * 

--- a/src/main/java/org/crosswire/jsword/book/sword/SwordDictionary.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/SwordDictionary.java
@@ -75,8 +75,7 @@ public class SwordDictionary extends AbstractBook {
         Element title = OSISUtil.factory().createTitle();
         title.addContent(key.getName());
         content.add(title);
-  
-        
+
         OpenFileState state = null;
         String txt = null;
         try {
@@ -87,14 +86,12 @@ public class SwordDictionary extends AbstractBook {
         } finally {
             IOUtil.close(state);
         }
-  
+
         List<Content> osisContent = filter.toOSIS(this, key, txt);
         content.addAll(osisContent);
-  
+
         return content.iterator();
     }
-
-
 
     /* (non-Javadoc)
      * @see org.crosswire.jsword.book.Book#getRawText(org.crosswire.jsword.passage.Key)
@@ -110,8 +107,7 @@ public class SwordDictionary extends AbstractBook {
             IOUtil.close(state);
         }
     }
-    
-    
+
     /* (non-Javadoc)
      * @see org.crosswire.jsword.book.Book#contains(org.crosswire.jsword.passage.Key)
      */

--- a/src/main/java/org/crosswire/jsword/book/sword/SwordGenBook.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/SwordGenBook.java
@@ -76,7 +76,7 @@ public class SwordGenBook extends AbstractBook {
 
         set = backend.readIndex();
 
-        map = new HashMap<String,Key>();
+        map = new HashMap<String, Key>();
         for (Key key : set) {
             map.put(key.getName(), key);
         }
@@ -271,7 +271,7 @@ public class SwordGenBook extends AbstractBook {
     /**
      * So we can quickly find a Key given the text for the key
      */
-    private Map<String,Key> map;
+    private Map<String, Key> map;
 
     /**
      * So we can implement getIndex() easily

--- a/src/main/java/org/crosswire/jsword/book/sword/SwordUtil.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/SwordUtil.java
@@ -388,7 +388,7 @@ public final class SwordUtil {
 
         return loc;
     }
-    
+
     /**
      * The log stream
      */

--- a/src/main/java/org/crosswire/jsword/book/sword/ZLDBackend.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/ZLDBackend.java
@@ -48,21 +48,21 @@ public class ZLDBackend extends RawLDBackend<ZLDBackendState> {
     }
 
     @Override
-    public ZLDBackendState initState() throws BookException{
+    public ZLDBackendState initState() throws BookException {
         return OpenFileStateManager.getZLDBackendState(getBookMetaData());
-     }
-    
+    }
+
     @Override
     protected String getRawText(RawLDBackendState fileState, DataEntry entry) {
         ZLDBackendState state = null;
-        if(fileState instanceof ZLDBackendState) {
+        if (fileState instanceof ZLDBackendState) {
             state = (ZLDBackendState) fileState;
         } else {
             //something went terribly wrong
             log.error("Backend State was not of type ZLDBackendState. Ignoring this entry and exiting.");
             return "";
         }
-        
+
         DataIndex blockIndex = entry.getBlockIndex();
         long blockNum = blockIndex.getOffset();
         int blockEntry = blockIndex.getSize();
@@ -113,9 +113,6 @@ public class ZLDBackend extends RawLDBackend<ZLDBackendState> {
         return SwordUtil.decode(entry.getName(), entryBytes, getBookMetaData().getBookCharset()).trim();
     }
 
-   
-
-
     /**
      * Serialization support.
      * 
@@ -127,11 +124,9 @@ public class ZLDBackend extends RawLDBackend<ZLDBackendState> {
         is.defaultReadObject();
     }
 
-
     private static final int ZDX_ENTRY_SIZE = 8;
     private static final int BLOCK_ENTRY_COUNT = 4;
     private static final int BLOCK_ENTRY_SIZE = 8;
-
 
     /**
      * The log stream

--- a/src/main/java/org/crosswire/jsword/book/sword/processing/NoOpRawTextProcessor.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/processing/NoOpRawTextProcessor.java
@@ -1,3 +1,23 @@
+/**
+ * Distribution License:
+ * JSword is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License, version 2.1 as published by
+ * the Free Software Foundation. This program is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The License is available on the internet at:
+ *       http://www.gnu.org/copyleft/lgpl.html
+ * or by writing to:
+ *      Free Software Foundation, Inc.
+ *      59 Temple Place - Suite 330
+ *      Boston, MA 02111-1307, USA
+ *
+ * Copyright: 2012
+ *     The copyright to this program is held by it's authors.
+ *
+ */
 package org.crosswire.jsword.book.sword.processing;
 
 import java.util.List;
@@ -6,16 +26,32 @@ import org.crosswire.jsword.passage.Key;
 import org.crosswire.jsword.passage.VerseRange;
 import org.jdom.Content;
 
+/**
+ * A processor that does absolutely nothing.
+ *
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author DM Smith [dmsmith555 at yahoo dot com]
+ */
 public class NoOpRawTextProcessor implements RawTextToXmlProcessor {
 
+    /* (non-Javadoc)
+     * @see org.crosswire.jsword.book.sword.processing.RawTextToXmlProcessor#preRange(org.crosswire.jsword.passage.VerseRange, java.util.List)
+     */
     public void preRange(VerseRange range, List<Content> partialDom) {
         // No-Op
     }
 
+    /* (non-Javadoc)
+     * @see org.crosswire.jsword.book.sword.processing.RawTextToXmlProcessor#postVerse(org.crosswire.jsword.passage.Key, java.util.List, java.lang.String)
+     */
     public void postVerse(Key verse, List<Content> partialDom, String rawText) {
         // No-Op
     }
 
+    /* (non-Javadoc)
+     * @see org.crosswire.jsword.book.sword.processing.RawTextToXmlProcessor#init(java.util.List)
+     */
     public void init(List<Content> partialDom) {
         // No-Op
     }

--- a/src/main/java/org/crosswire/jsword/book/sword/processing/RawTextToXmlProcessor.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/processing/RawTextToXmlProcessor.java
@@ -1,3 +1,23 @@
+/**
+ * Distribution License:
+ * JSword is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License, version 2.1 as published by
+ * the Free Software Foundation. This program is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The License is available on the internet at:
+ *       http://www.gnu.org/copyleft/lgpl.html
+ * or by writing to:
+ *      Free Software Foundation, Inc.
+ *      59 Temple Place - Suite 330
+ *      Boston, MA 02111-1307, USA
+ *
+ * Copyright: 2012
+ *     The copyright to this program is held by it's authors.
+ *
+ */
 package org.crosswire.jsword.book.sword.processing;
 
 import java.util.List;
@@ -7,8 +27,8 @@ import org.crosswire.jsword.passage.VerseRange;
 import org.jdom.Content;
 
 /**
- * This interface declares operations to be carried out after Raw Text has been read from a backend, before it is returned as OSIS to the caller
- *
+ * This interface declares operations to be carried out after Raw Text
+ *  has been read from a backend, before it is returned as OSIS to the caller.
  *
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's authors.
@@ -16,20 +36,23 @@ import org.jdom.Content;
  */
 public interface RawTextToXmlProcessor {
     /**
-     * Runs before the processing starts
-     * @param partialDom the dom, empty at this stage
+     * Runs before the processing starts.
+     * 
+     * @param partialDom the DOM, empty at this stage
      */
     void init(List<Content> partialDom);
-    
+
     /**
-     * Executes before a range is read from the raw data
+     * Executes before a range is read from the raw data.
+     * 
      * @param range the verse that is currently being examined
      * @param partialDom the DOM that is being built up as data is read
      */
     void preRange(VerseRange range, List<Content> partialDom);
 
     /**
-     * Executes after a verse is read from the raw data
+     * Executes after a verse is read from the raw data.
+     * 
      * @param verse the verse that is currently being examined
      * @param partialDom the DOM that is being built up as data is read
      * @param rawText the text that has been read, deciphered

--- a/src/main/java/org/crosswire/jsword/book/sword/processing/package.html
+++ b/src/main/java/org/crosswire/jsword/book/sword/processing/package.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+
+<p>
+  Interface and default implementation for the transformation of raw text into XML.
+</p>
+
+</body>
+</html>

--- a/src/main/java/org/crosswire/jsword/book/sword/state/AbstractOpenFileState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/AbstractOpenFileState.java
@@ -20,7 +20,6 @@
  */
 package org.crosswire.jsword.book.sword.state;
 
-
 /**
   *
  * @see gnu.lgpl.License for license details.<br>
@@ -28,7 +27,6 @@ package org.crosswire.jsword.book.sword.state;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public abstract class AbstractOpenFileState implements OpenFileState {
-    
     /**
      * Allows us to decide whether to release the resources or continue using them
      */

--- a/src/main/java/org/crosswire/jsword/book/sword/state/GenBookBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/GenBookBackendState.java
@@ -45,23 +45,6 @@ import org.crosswire.jsword.book.sword.SwordUtil;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class GenBookBackendState extends AbstractOpenFileState {
-    /** The log stream */
-    private static final Logger log = Logger.getLogger(GenBookBackendState.class);
-    /**
-     * Raw GenBook file extensions
-     */
-    private static final String EXTENSION_BDT = ".bdt";
-
-    /**
-     * The raw data file
-     */
-    private File bdtFile;
-    /**
-     * The random access file for the raw data
-     */
-    private RandomAccessFile bdtRaf;
-    private SwordBookMetaData bookMetaData;
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
@@ -119,4 +102,22 @@ public class GenBookBackendState extends AbstractOpenFileState {
     public SwordBookMetaData getBookMetaData() {
         return bookMetaData;
     }
+
+    /**
+     * Raw GenBook file extensions
+     */
+    private static final String EXTENSION_BDT = ".bdt";
+
+    /**
+     * The raw data file
+     */
+    private File bdtFile;
+    /**
+     * The random access file for the raw data
+     */
+    private RandomAccessFile bdtRaf;
+    private SwordBookMetaData bookMetaData;
+
+    /** The log stream */
+    private static final Logger log = Logger.getLogger(GenBookBackendState.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/RawBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/RawBackendState.java
@@ -47,26 +47,12 @@ import org.crosswire.jsword.book.sword.SwordUtil;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class RawBackendState extends AbstractOpenFileState {
-    /** The log stream */
-    private static final Logger log = Logger.getLogger(RawBackendState.class);
-
-    protected RandomAccessFile otIdxRaf;
-    protected RandomAccessFile ntIdxRaf;
-    protected RandomAccessFile otTextRaf;
-    protected RandomAccessFile ntTextRaf;
-    protected File ntIdxFile;
-    protected File ntTextFile;
-    protected File otIdxFile;
-    protected File otTextFile;
-
-    private SwordBookMetaData bookMetaData;
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
      * new instances of OpenFileState being created for no reason, and as a
      * result, if they are released to the OpenFileStateManager by mistake this
-     * would result in leakage
+     * would result in leakage.
      * 
      * @param bookMetaData
      *            the appropriate metadata for the book
@@ -82,7 +68,7 @@ public class RawBackendState extends AbstractOpenFileState {
         URI ntPath = NetUtil.lengthenURI(path, File.separator + SwordConstants.FILE_NT);
         ntTextFile = new File(ntPath.getPath());
         ntIdxFile = new File(ntPath.getPath() + SwordConstants.EXTENSION_VSS);
-        
+
         // It is an error to be neither OT nor NT
         // Throwing exception, as if we can't read either the ot or nt file,
         // then we might as well give up
@@ -102,9 +88,9 @@ public class RawBackendState extends AbstractOpenFileState {
                 //failed to open the files, so close them now
                 IOUtil.close(otIdxRaf);
                 IOUtil.close(otTextRaf);
-                
+
                 assert false : ex;
-            
+
                 log.error("Could not open OT", ex);
                 ntIdxRaf = null;
                 ntTextRaf = null;
@@ -226,4 +212,18 @@ public class RawBackendState extends AbstractOpenFileState {
     public SwordBookMetaData getBookMetaData() {
         return bookMetaData;
     }
+
+    protected RandomAccessFile otIdxRaf;
+    protected RandomAccessFile ntIdxRaf;
+    protected RandomAccessFile otTextRaf;
+    protected RandomAccessFile ntTextRaf;
+    protected File ntIdxFile;
+    protected File ntTextFile;
+    protected File otIdxFile;
+    protected File otTextFile;
+
+    private SwordBookMetaData bookMetaData;
+
+    /** The log stream */
+    private static final Logger log = Logger.getLogger(RawBackendState.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/RawFileBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/RawFileBackendState.java
@@ -42,12 +42,6 @@ import org.crosswire.jsword.book.sword.SwordUtil;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class RawFileBackendState extends RawBackendState {
-    public static final String INCFILE = "incfile";
-    /** The log stream */
-    private static final Logger log = Logger.getLogger(RawFileBackendState.class);
-    private File incfile;
-    private Integer incfileValue;
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
@@ -68,19 +62,19 @@ public class RawFileBackendState extends RawBackendState {
     public boolean isWritable() {
         File incFile = getIncfile();
 
-            if(existsAndCanReadAndWrite(otTextFile) && 
-                    existsAndCanReadAndWrite(ntTextFile) && 
-                    existsAndCanReadAndWrite(otIdxFile) && 
-                    existsAndCanReadAndWrite(otTextFile) && 
-                    (incFile == null || existsAndCanReadAndWrite(incFile))) {
-                return true;
-            }
-            return false;
+        if (existsAndCanReadAndWrite(otTextFile)
+                && existsAndCanReadAndWrite(ntTextFile)
+                && existsAndCanReadAndWrite(otIdxFile)
+                && existsAndCanReadAndWrite(otTextFile)
+                && (incFile == null || existsAndCanReadAndWrite(incFile)))
+        {
+            return true;
+        }
+        return false;
     }
-    
+
     /**
      * Returns true if the file exists, can be read and can be written to.
-     * 
      *
      * @param file the file
      * @return true, if successful
@@ -88,7 +82,6 @@ public class RawFileBackendState extends RawBackendState {
     private boolean existsAndCanReadAndWrite(File file) {
         return file.exists() && file.canRead() && file.canWrite();
     }
-    
 
     private int readIncfile() throws IOException {
         int ret = -1;
@@ -151,7 +144,6 @@ public class RawFileBackendState extends RawBackendState {
 
     public void setIncfileValue(int incValue) {
         this.incfileValue = incValue;
-
     }
 
     /**
@@ -172,4 +164,10 @@ public class RawFileBackendState extends RawBackendState {
         this.incfile = incfile;
     }
 
+    public static final String INCFILE = "incfile";
+    private File incfile;
+    private Integer incfileValue;
+
+    /** The log stream */
+    private static final Logger log = Logger.getLogger(RawFileBackendState.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/RawLDBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/RawLDBackendState.java
@@ -45,33 +45,6 @@ import org.crosswire.jsword.book.sword.SwordUtil;
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class RawLDBackendState extends AbstractOpenFileState  {
-    private static final Logger log = Logger.getLogger(RawLDBackend.class);
-    /**
-     * The number of entries in the book.
-     */
-    private int size = -1;
-
-    /**
-     * The index file
-     */
-    private File idxFile;
-
-    /**
-     * The index random access file
-     */
-    private RandomAccessFile idxRaf;
-
-    /**
-     * The data file
-     */
-    private File datFile;
-
-    /**
-     * The data random access file
-     */
-    private RandomAccessFile datRaf;
-    private SwordBookMetaData bookMetaData;
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
@@ -124,7 +97,6 @@ public class RawLDBackendState extends AbstractOpenFileState  {
             IOUtil.close(idxRaf);
             IOUtil.close(datRaf);
 
-            
             log.error("failed to open files", ex);
             idxRaf = null;
             datRaf = null;
@@ -183,4 +155,31 @@ public class RawLDBackendState extends AbstractOpenFileState  {
         return this.bookMetaData;
     }
 
+    /**
+     * The number of entries in the book.
+     */
+    private int size = -1;
+
+    /**
+     * The index file
+     */
+    private File idxFile;
+
+    /**
+     * The index random access file
+     */
+    private RandomAccessFile idxRaf;
+
+    /**
+     * The data file
+     */
+    private File datFile;
+
+    /**
+     * The data random access file
+     */
+    private RandomAccessFile datRaf;
+    private SwordBookMetaData bookMetaData;
+
+    private static final Logger log = Logger.getLogger(RawLDBackend.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/ZLDBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/ZLDBackendState.java
@@ -35,55 +35,16 @@ import org.crosswire.jsword.book.sword.SwordBookMetaData;
 import org.crosswire.jsword.book.sword.SwordUtil;
 
 /**
- * Stores the random access files required for processing the passage request
+ * Stores the random access files required for processing the passage request.
  * 
  * The caller is required to close to correctly free resources and avoid File
- * pointer leaks
+ * pointer leaks.
  * 
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's authors.
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class ZLDBackendState extends RawLDBackendState {
-    /**
-     * The log stream
-     */
-    private static final Logger log = Logger.getLogger(ZLDBackendState.class);
-    private static final byte[] EMPTY_BYTES = new byte[0];
-    private static final String EXTENSION_Z_INDEX = ".zdx";
-    private static final String EXTENSION_Z_DATA = ".zdt";
-    
-    /**
-     * The compressed index.
-     */
-    private File zdxFile;
-
-    /**
-     * The compressed index random access file.
-     */
-    private RandomAccessFile zdxRaf;
-
-    /**
-     * The compressed text.
-     */
-    private  File zdtFile;
-
-    /**
-     * The compressed text random access file.
-     */
-    private  RandomAccessFile zdtRaf;
-
-    /**
-     * The index of the block that is cached.
-     */
-    private  long lastBlockNum;
-
-    /**
-     * The cache for a read of a compressed block.
-     */
-    private  byte[] lastUncompressed;
-
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
@@ -135,15 +96,13 @@ public class ZLDBackendState extends RawLDBackendState {
             //failed to open the files, so close them now
             IOUtil.close(zdxRaf);
             IOUtil.close(zdtRaf);
-            
+
             log.error("failed to open files", ex);
             zdxRaf = null;
             zdtRaf = null;
             return;
         }
     }
-    
-    
 
     public void releaseResources() {
         super.releaseResources();
@@ -156,16 +115,12 @@ public class ZLDBackendState extends RawLDBackendState {
             zdtRaf = null;
     }
 
-
-
     /**
      * @return the zdxRaf
      */
     public RandomAccessFile getZdxRaf() {
         return zdxRaf;
     }
-
-
 
     /**
      * @return the zdtRaf
@@ -174,8 +129,6 @@ public class ZLDBackendState extends RawLDBackendState {
         return zdtRaf;
     }
 
-
-
     /**
      * @return the lastBlockNum
      */
@@ -183,16 +136,12 @@ public class ZLDBackendState extends RawLDBackendState {
         return lastBlockNum;
     }
 
-
-
     /**
      * @return the lastUncompressed
      */
     public byte[] getLastUncompressed() {
         return lastUncompressed;
     }
-
-
 
     /**
      * @param lastBlockNum the lastBlockNum to set
@@ -208,5 +157,42 @@ public class ZLDBackendState extends RawLDBackendState {
         this.lastUncompressed = lastUncompressed;
     }
 
-    
+    private static final byte[] EMPTY_BYTES = new byte[0];
+    private static final String EXTENSION_Z_INDEX = ".zdx";
+    private static final String EXTENSION_Z_DATA = ".zdt";
+
+    /**
+     * The compressed index.
+     */
+    private File zdxFile;
+
+    /**
+     * The compressed index random access file.
+     */
+    private RandomAccessFile zdxRaf;
+
+    /**
+     * The compressed text.
+     */
+    private  File zdtFile;
+
+    /**
+     * The compressed text random access file.
+     */
+    private  RandomAccessFile zdtRaf;
+
+    /**
+     * The index of the block that is cached.
+     */
+    private  long lastBlockNum;
+
+    /**
+     * The cache for a read of a compressed block.
+     */
+    private  byte[] lastUncompressed;
+
+    /**
+     * The log stream
+     */
+    private static final Logger log = Logger.getLogger(ZLDBackendState.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/ZVerseBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/ZVerseBackendState.java
@@ -37,48 +37,16 @@ import org.crosswire.jsword.book.sword.SwordUtil;
 import org.crosswire.jsword.versification.Testament;
 
 /**
- * Stores the random access files required for processing the passage request
+ * Stores the random access files required for processing the passage request.
  * 
  * The caller is required to close to correctly free resources and avoid File
- * pointer leaks
+ * pointer leaks.
  * 
  * @see gnu.lgpl.License for license details.<br>
  *      The copyright to this program is held by it's authors.
  * @author DM Smith [dmsmith555 at yahoo dot com]
  */
 public class ZVerseBackendState extends AbstractOpenFileState {
-    private static final String SUFFIX_COMP = "v";
-    private static final String SUFFIX_INDEX = "s";
-    private static final String SUFFIX_PART1 = "z";
-    private static final String SUFFIX_TEXT = "z";
-
-    /**
-     * The log stream
-     */
-    private static final Logger log = Logger.getLogger(ZVerseBackendState.class);
-
-    /**
-     * The index random access files
-     */
-    private RandomAccessFile otIdxRaf;
-    private RandomAccessFile ntIdxRaf;
-
-    /**
-     * The data random access files
-     */
-    private RandomAccessFile otTextRaf;
-    private RandomAccessFile ntTextRaf;
-
-    /**
-     * The compressed random access files
-     */
-    private RandomAccessFile otCompRaf;
-    private RandomAccessFile ntCompRaf;
-    private Testament lastTestament;
-    private long lastBlockNum = -1;
-    private byte[] lastUncompressed;
-    private SwordBookMetaData bookMetaData;
-
     /**
      * This is default package access for forcing the use of the
      * OpenFileStateManager to manage the creation. Not doing so may result in
@@ -113,7 +81,6 @@ public class ZVerseBackendState extends AbstractOpenFileState {
                 IOUtil.close(otTextRaf);
                 IOUtil.close(otCompRaf);
 
-                
                 assert false : ex;
                 log.error("Could not open OT", ex);
             }
@@ -246,4 +213,35 @@ public class ZVerseBackendState extends AbstractOpenFileState {
     public SwordBookMetaData getBookMetaData() {
         return bookMetaData;
     }
+    private static final String SUFFIX_COMP = "v";
+    private static final String SUFFIX_INDEX = "s";
+    private static final String SUFFIX_PART1 = "z";
+    private static final String SUFFIX_TEXT = "z";
+
+    /**
+     * The index random access files
+     */
+    private RandomAccessFile otIdxRaf;
+    private RandomAccessFile ntIdxRaf;
+
+    /**
+     * The data random access files
+     */
+    private RandomAccessFile otTextRaf;
+    private RandomAccessFile ntTextRaf;
+
+    /**
+     * The compressed random access files
+     */
+    private RandomAccessFile otCompRaf;
+    private RandomAccessFile ntCompRaf;
+    private Testament lastTestament;
+    private long lastBlockNum = -1;
+    private byte[] lastUncompressed;
+    private SwordBookMetaData bookMetaData;
+
+    /**
+     * The log stream
+     */
+    private static final Logger log = Logger.getLogger(ZVerseBackendState.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/package.html
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/package.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+
+<p>
+  File management of SWORD Books.
+</p>
+
+</body>
+</html>

--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
@@ -115,7 +115,7 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
      * Combines the strong numbers with the morphology field
      */
     public static final String FIELD_MORPHOLOGY = "morph";
-    
+
     /**
      * Read an existing index and use it.
      * 
@@ -234,7 +234,6 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
         } finally {
             book.setIndexStatus(finalStatus);
             job.done();
-            
         }
     }
 
@@ -248,8 +247,8 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
         } catch (IOException ex) {
             log.warn("second load failure", ex);
         }
-    } 
-    
+    }
+
     /*
      * (non-Javadoc)
      * 
@@ -326,7 +325,7 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
             } catch (ParseException e) {
                 // TRANSLATOR: Error condition: An unexpected error happened that caused search to fail.
                 throw new BookException(JSMsg.gettext("Search failed."), e);
-            } 
+            }
         }
 
         if (results == null) {
@@ -354,13 +353,13 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
         } catch (IOException ex) {
             Reporter.informUser(this, ex);
         }
-        
+
         try {
             directory.close();
-        } catch(IOException ex) {
+        } catch (IOException ex) {
             Reporter.informUser(this,  ex);
         }
-        
+
         searcher = null;
         directory = null;
     }
@@ -376,7 +375,7 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
         boolean hasNotes = book.getBookMetaData().hasFeature(FeatureType.FOOTNOTES);
         boolean hasHeadings = book.getBookMetaData().hasFeature(FeatureType.HEADINGS);
         boolean hasMorphology = book.getBookMetaData().hasFeature(FeatureType.MORPHOLOGY);
-        
+
         String oldRootName = "";
         int percent = 0;
         String rootName = "";
@@ -392,7 +391,7 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
         Field noteField = new Field(FIELD_NOTE, "", Field.Store.NO, Field.Index.ANALYZED, Field.TermVector.NO);
         Field headingField = new Field(FIELD_HEADING, "", Field.Store.NO, Field.Index.ANALYZED, Field.TermVector.NO);
         Field morphologyField  = new Field(FIELD_MORPHOLOGY , "", Field.Store.NO, Field.Index.ANALYZED, Field.TermVector.NO);
-        
+
         int size = key.getCardinality();
         int subCount = count;
         for (Key subkey : key) {
@@ -435,10 +434,10 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
                     addField(doc, headingField, OSISUtil.getHeadings(osis));
                 }
 
-                if(hasMorphology) {
+                if (hasMorphology) {
                     addField(doc, morphologyField, OSISUtil.getMorphologiesWithStrong(osis));
                 }
-                
+
                 // Add the document if we added more than just the key.
                 if (doc.getFields().size() > 1) {
                     writer.addDocument(doc);
@@ -479,7 +478,8 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
      * Could be null if the index has been closed down. This is helpful to third party applications which wish to have greater control over 
      * the underlying Lucene functionality.
      * 
-     * Note: by using this method, you need to ensure you don't close the searcher while it is being used. See {@link IndexManager#closeAllIndexes()} for more information
+     * Note: by using this method, you need to ensure you don't close the searcher while it is being used.
+     * See {@link IndexManager#closeAllIndexes()} for more information
      */
     public Searcher getSearcher() {
         return searcher;

--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndexManager.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndexManager.java
@@ -86,13 +86,13 @@ public class LuceneIndexManager implements IndexManager {
             throw new BookException(JSMsg.gettext("Failed to initialize Lucene search engine."), ex);
         }
     }
-    
+
     /*
      *     @Override(non-Javadoc)
      * @see org.crosswire.jsword.index.IndexManager#closeAllIndexes()
      */
     public void closeAllIndexes() {
-        for(Index index : INDEXES.values()) {
+        for (Index index : INDEXES.values()) {
             index.close();
         }
     }
@@ -166,19 +166,19 @@ public class LuceneIndexManager implements IndexManager {
             // TODO(joe): This needs some checks that it isn't being used
             //temporary fix, which closes the index - non-thread safe since someone could theoretically come in and activate this again!
             Index index = INDEXES.get(book);
-            if(index != null) {
+            if (index != null) {
                 index.close();
             }
-            
+
             File storage = NetUtil.getAsFile(getStorageArea(book));
             String finalCanonicalPath = storage.getCanonicalPath();
             tempPath = new File(finalCanonicalPath + '.' + IndexStatus.CREATING.toString());
-            
-            if(tempPath.exists()) {
+
+            if (tempPath.exists()) {
                 FileUtil.delete(tempPath);
             }
 
-            //Issues in at least Windows seem to create issues with reusing a file that's been deleted... 
+            // Issues in at least Windows seem to create issues with reusing a file that's been deleted... 
             tempPath = new File(finalCanonicalPath + '.' + IndexStatus.CREATING.toString());
             if (!storage.renameTo(tempPath)) {
                 // TRANSLATOR: Error condition: The index could not be deleted.

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/LuceneAnalyzer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/LuceneAnalyzer.java
@@ -17,18 +17,15 @@
  * Copyright: 2005
  *     The copyright to this program is held by it's authors.
  *
- * ID: $Id:LuceneIndex.java 984 2006-01-23 14:18:33 -0500 (Mon, 23 Jan 2006) dmsmith $
  */
 package org.crosswire.jsword.index.lucene.analysis;
 
 import java.io.Reader;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.KeywordAnalyzer;
 import org.apache.lucene.analysis.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.SimpleAnalyzer;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.WhitespaceAnalyzer;
 import org.crosswire.jsword.book.Book;
 import org.crosswire.jsword.index.lucene.IndexMetadata;
 import org.crosswire.jsword.index.lucene.LuceneIndex;
@@ -63,10 +60,9 @@ public class LuceneAnalyzer extends Analyzer {
         // Strong's Numbers are normalized to a consistent representation
         analyzer.addAnalyzer(LuceneIndex.FIELD_STRONG, new StrongsNumberAnalyzer());
 
-        // Keywords are normalized to osisIDs
+        // Strong's Numbers and Robinson's morphological codes are normalized to a consistent representation
         analyzer.addAnalyzer(LuceneIndex.FIELD_MORPHOLOGY, new MorphologyAnalyzer());
-        
-        
+
         // XRefs are normalized from ranges into a list of osisIDs
         analyzer.addAnalyzer(LuceneIndex.FIELD_XREF, new XRefAnalyzer());
     }

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/MorphologyAnalyzer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/MorphologyAnalyzer.java
@@ -1,3 +1,23 @@
+/**
+ * Distribution License:
+ * JSword is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License, version 2.1 as published by
+ * the Free Software Foundation. This program is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The License is available on the internet at:
+ *       http://www.gnu.org/copyleft/lgpl.html
+ * or by writing to:
+ *      Free Software Foundation, Inc.
+ *      59 Temple Place - Suite 330
+ *      Boston, MA 02111-1307, USA
+ *
+ * Copyright: 2012
+ *     The copyright to this program is held by it's authors.
+ *
+ */
 package org.crosswire.jsword.index.lucene.analysis;
 
 import java.io.Reader;
@@ -6,6 +26,13 @@ import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.WhitespaceAnalyzer;
 
+/**
+ * Robinson Morphological Codes are separated by whitespace.
+ *
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author DM Smith [dmsmith555 at yahoo dot com]
+ */
 public class MorphologyAnalyzer extends AbstractBookAnalyzer {
 
     @Override

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/SmartChineseLuceneAnalyzer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/SmartChineseLuceneAnalyzer.java
@@ -31,7 +31,7 @@ import org.apache.lucene.util.Version;
 /**
  * A simple wrapper for {@link SmartChineseAnalyzer}, which takes overlapping
  * two character tokenization approach which leads to larger index size, like
- * {@link org.apache.lucene.analyzer.cjk.CJKAnalyzer}. This analyzer's stop list
+ * <code>org.apache.lucene.analyzer.cjk.CJKAnalyzer</code>. This analyzer's stop list
  * is merely of punctuation. It does stemming of English.
  * 
  * @see gnu.lgpl.License for license details.<br>

--- a/src/main/java/org/crosswire/jsword/internationalisation/DefaultLocaleProvider.java
+++ b/src/main/java/org/crosswire/jsword/internationalisation/DefaultLocaleProvider.java
@@ -17,13 +17,17 @@
  * Copyright: 2013
  *     The copyright to this program is held by it's authors.
  *
- * ID: $Id$
- */package org.crosswire.jsword.internationalisation;
+ */
+package org.crosswire.jsword.internationalisation;
 
 import java.util.Locale;
 
 /**
  * A default Locale provider simply returns Locale.getDefault()
+ *
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author Chris Burrell
  */
 public class DefaultLocaleProvider implements LocaleProvider {
 

--- a/src/main/java/org/crosswire/jsword/internationalisation/LocaleProvider.java
+++ b/src/main/java/org/crosswire/jsword/internationalisation/LocaleProvider.java
@@ -17,18 +17,19 @@
  * Copyright: 2013
  *     The copyright to this program is held by it's authors.
  *
- * ID: $Id$
  */
 package org.crosswire.jsword.internationalisation;
 
 import java.util.Locale;
 
-
 /**
  * Provides the correct Locale to use
+ *
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author Chris Burrell
  */
 public interface LocaleProvider {
-    
     /**
      * Gets the user locale.
      *

--- a/src/main/java/org/crosswire/jsword/internationalisation/LocaleProviderManager.java
+++ b/src/main/java/org/crosswire/jsword/internationalisation/LocaleProviderManager.java
@@ -17,7 +17,6 @@
  * Copyright: 2013
  *     The copyright to this program is held by it's authors.
  *
- * ID: $Id$
  */
 package org.crosswire.jsword.internationalisation;
 
@@ -28,18 +27,19 @@ import java.util.Locale;
  * <p />
  * It is expected that the LocaleProvider will only be set once, as a result, no effort is made to make this thread-safe as this should happen on
  * start up of the application. A default locale provider is given which simply returns the default locale. See {@link DefaultLocaleProvider} for more details.
+ *
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author Chris Burrell
  */
 public class LocaleProviderManager {
-    private static LocaleProvider localeProvider = new DefaultLocaleProvider();
-
-    
     /**
      * Prevent public access. Instantiates a new locale provider factory.
      */
     private LocaleProviderManager() {
         //No OP
     }
-    
+
     /**
      * Gets the locale provider.
      *
@@ -48,7 +48,7 @@ public class LocaleProviderManager {
     public static LocaleProvider getLocaleProvider() {
         return localeProvider;
     }
-    
+
     /**
      * Gets the locale to be used by the JSword library
      *
@@ -57,7 +57,7 @@ public class LocaleProviderManager {
     public static Locale getLocale() {
         return localeProvider.getUserLocale();
     }
-    
+
     /**
      * Allow third-party applications to.
      *
@@ -66,4 +66,6 @@ public class LocaleProviderManager {
     public static void setLocaleProvider(LocaleProvider provider) {
         localeProvider = provider;
     }
+
+    private static LocaleProvider localeProvider = new DefaultLocaleProvider();
 }

--- a/src/main/java/org/crosswire/jsword/passage/AbstractPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/AbstractPassage.java
@@ -109,7 +109,6 @@ public abstract class AbstractPassage implements Passage {
         Verse thatfirst = thatref.getVerseAt(0);
         Verse thisfirst = getVerseAt(0);
 
-        
         return getVersification().distance(thisfirst, thatfirst);
     }
 
@@ -973,7 +972,7 @@ public abstract class AbstractPassage implements Passage {
      * @return The VerseRange
      * @exception java.lang.ClassCastException
      *                If this is not a Verse or a VerseRange
-     * @deprecated  use {@link #toVerseRange(Versification, String)} instead
+     * @deprecated  use {@link #toVerseRange(Versification, Object)} instead
      */
     @Deprecated
     protected static VerseRange toVerseRange(Object base) throws ClassCastException {

--- a/src/main/java/org/crosswire/jsword/passage/BitwisePassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/BitwisePassage.java
@@ -120,11 +120,11 @@ public class BitwisePassage extends AbstractPassage {
         Versification v11n = getVersification();
         for (Key aKey : obj) {
             Verse verse = (Verse) aKey;
-            if(verse.getVerse() == 0) {
+            if (verse.getVerse() == 0) {
                 //skip - as not all modules have verse 0
                 continue;
             }
-            
+
             if (!store.get(v11n.getOrdinal(verse))) {
                 return false;
             }

--- a/src/main/java/org/crosswire/jsword/passage/KeyUtil.java
+++ b/src/main/java/org/crosswire/jsword/passage/KeyUtil.java
@@ -62,6 +62,7 @@ public final class KeyUtil {
     /**
      * Not all keys represent verses, but we ought to be able to get something
      * close to a verse from anything that does verse like work.
+     * @deprecated use {@link #getPassage(Key, Versification)}
      */
     @Deprecated
     public static Verse getVerse(Key key) {
@@ -90,19 +91,18 @@ public final class KeyUtil {
         }
     }
 
-    
-    
     /**
      * Not all keys represent passages, but we ought to be able to get something
      * close to a passage from anything that does passage like work. If you pass
      * a null key into this method, you get a null Passage out.
+     * 
+     * @deprecated {@link #getPassage(Key, Versification)}
      */
     @Deprecated
     public static Passage getPassage(Key key) {
         return getPassage(key, Versifications.instance().getDefaultVersification());
     }
-    
-    
+
     /**
      * Not all keys represent passages, but we ought to be able to get something
      * close to a passage from anything that does passage like work. If you pass

--- a/src/main/java/org/crosswire/jsword/passage/Verse.java
+++ b/src/main/java/org/crosswire/jsword/passage/Verse.java
@@ -247,7 +247,8 @@ public final class Verse implements Key {
         return getOrdinal();
     }
 
-    /* (non-Javadoc)
+    /**
+     * @deprecated Use {@link Versification#distance(Verse, Verse)}
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     @Deprecated
@@ -279,7 +280,7 @@ public final class Verse implements Key {
      * @param that
      *            The thing to compare against
      * @return 1 means he is earlier than me, -1 means he is later ...
-     * @deprecated
+     * @deprecated Use {@link Versification#adjacentTo(Verse, Verse)}
      */
     @Deprecated
     public boolean adjacentTo(Verse that) {
@@ -294,7 +295,7 @@ public final class Verse implements Key {
      * @param start
      *            The Verse to compare this to
      * @return The count of verses between this and that.
-     * @deprecated
+     * @deprecated Use {@link Versification#distance(Verse, Verse)}
      */
     @Deprecated
     public int subtract(Verse start) {
@@ -307,7 +308,7 @@ public final class Verse implements Key {
      * @param n
      *            The number to count down by
      * @return The new Verse
-     * @deprecated
+     * @deprecated Use {@link Versification#subtract(Verse, int)}
      */
     @Deprecated
     public Verse subtract(int n) {
@@ -321,7 +322,7 @@ public final class Verse implements Key {
      * @param n
      *            the number of verses later than the one we're one
      * @return The new verse
-     * @deprecated
+     * @deprecated Use {@link Versification#add(Verse, int)}
      */
     @Deprecated
     public Verse add(int n) {
@@ -360,7 +361,7 @@ public final class Verse implements Key {
      * Is this verse the first in a chapter
      * 
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isStartOfChapter(Verse)}
      */
     @Deprecated
     public boolean isStartOfChapter() {
@@ -371,7 +372,7 @@ public final class Verse implements Key {
      * Is this verse the first in a chapter
      * 
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isEndOfChapter(Verse)}
      */
     @Deprecated
     public boolean isEndOfChapter() {
@@ -383,7 +384,7 @@ public final class Verse implements Key {
      * Is this verse the first in a chapter
      * 
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isStartOfBook(Verse)}
      */
     @Deprecated
     public boolean isStartOfBook() {
@@ -394,7 +395,7 @@ public final class Verse implements Key {
      * Is this verse the first in a chapter
      * 
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isEndOfBook(Verse)}
      */
     @Deprecated
     public boolean isEndOfBook() {
@@ -408,7 +409,7 @@ public final class Verse implements Key {
      * @param that
      *            The verse to compare to
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isSameChapter(Verse,Verse)}
      */
     @Deprecated
     public boolean isSameChapter(Verse that) {
@@ -421,7 +422,7 @@ public final class Verse implements Key {
      * @param that
      *            The verse to compare to
      * @return true or false ...
-     * @deprecated
+     * @deprecated Use {@link Versification#isSameBook(Verse,Verse)}
      */
     @Deprecated
     public boolean isSameBook(Verse that) {
@@ -433,7 +434,7 @@ public final class Verse implements Key {
      * 31104
      * 
      * @return The verse number
-     * @deprecated do not use
+     * @deprecated Use {@link Versification#getOrdinal(Verse)}
      */
     @Deprecated
     public int getOrdinal() {
@@ -450,7 +451,7 @@ public final class Verse implements Key {
      * @param b
      *            The second verse to compare
      * @return The bigger of the 2 verses
-     * @deprecated do not use
+     * @deprecated Use {@link Versification#max(Verse,Verse)}
      */
     @Deprecated
     public static Verse max(Verse a, Verse b) {
@@ -469,7 +470,7 @@ public final class Verse implements Key {
      * @param b
      *            The second verse to compare
      * @return The smaller of the 2 verses
-     * @deprecated do not use
+     * @deprecated Use {@link Versification#min(Verse,Verse)}
      */
     @Deprecated
     public static Verse min(Verse a, Verse b) {
@@ -570,7 +571,7 @@ public final class Verse implements Key {
      *            The chapter to set
      * @param verse
      *            The verse to set
-     * @deprecated do not use
+     * @deprecated Use {@link Versification#patch(BibleBook,int,int)}
      */
     @Deprecated
     private void setAndPatch(BibleBook book, int chapter, int verse) {
@@ -605,7 +606,7 @@ public final class Verse implements Key {
      * 
      * @param ordinal
      *            The ordinal of the verse
-     * @deprecated do not use
+     * @deprecated Use {@link Versification#decodeOrdinal(int)}
      */
     @Deprecated
     private void set(int ordinal) {

--- a/src/main/java/org/crosswire/jsword/passage/VerseRange.java
+++ b/src/main/java/org/crosswire/jsword/passage/VerseRange.java
@@ -134,8 +134,8 @@ public final class VerseRange implements Key {
         shaper = new NumberShaper();
 
         int distance = v11n.distance(start, end);
-        
-        if(distance < 0) {
+
+        if (distance < 0) {
             this.start = end;
             this.end = start;
             this.verseCount = calcVerseCount();
@@ -850,10 +850,6 @@ public final class VerseRange implements Key {
     /**
      * Calculate the last verse in this range.
      * 
-     * @param start
-     *            The first verse in the range
-     * @param verseCount
-     *            The number of verses
      * @return The last verse in the range
      */
     private Verse calcEnd() {
@@ -866,10 +862,6 @@ public final class VerseRange implements Key {
     /**
      * Calculate how many verses in this range
      * 
-     * @param a
-     *            The first verse in the range
-     * @param b
-     *            The last verse in the range
      * @return The number of verses. Always >= 1.
      */
     private int calcVerseCount() {

--- a/src/main/java/org/crosswire/jsword/versification/BibleBook.java
+++ b/src/main/java/org/crosswire/jsword/versification/BibleBook.java
@@ -215,8 +215,6 @@ public enum BibleBook {
     /**
      * Get the BookName.
      *
-     * @param book
-     *            The book of the Bible
      * @return The requested BookName
      */
     public BookName getBookName() {
@@ -227,8 +225,6 @@ public enum BibleBook {
      * Get the preferred name of a book. Altered by the case setting (see
      * setBookCase() and isFullBookName())
      *
-     * @param book
-     *            The book of the Bible
      * @return The full name of the book
      */
     public String getPreferredName() {
@@ -239,8 +235,6 @@ public enum BibleBook {
      * Get the full name of a book (e.g. "Genesis"). Altered by the case setting
      * (see setBookCase())
      *
-     * @param book
-     *            The book of the Bible
      * @return The full name of the book
      */
     public String getLongName() {
@@ -251,8 +245,6 @@ public enum BibleBook {
      * Get the short name of a book (e.g. "Gen"). Altered by the case setting
      * (see setBookCase())
      *
-     * @param book
-     *            The book of the Bible
      * @return The short name of the book
      */
     public String getShortName() {
@@ -300,16 +292,16 @@ public enum BibleBook {
      */
     private static BibleNames getBibleNamesForLocale(Locale locale) {
         BibleNames bibleNames = localizedBibleNames.get(locale);
-        if(bibleNames == null) {
+        if (bibleNames == null) {
             synchronized (BibleBook.class) {
                 bibleNames = localizedBibleNames.get(locale);
-                if(bibleNames == null) {
+                if (bibleNames == null) {
                     bibleNames = new BibleNames(locale);
                     localizedBibleNames.put(locale, bibleNames);
                 }
             }
         }
-        
+
         return bibleNames;
     }
 
@@ -363,11 +355,11 @@ public enum BibleBook {
     private static BibleBook[] books = BibleBook.values();
 
     /** we cache the Localised Bible Names because there is quite a bit of processing going on for each individual Locale */
-    private static Map<Locale, BibleNames> localizedBibleNames = new HashMap<Locale,BibleNames>();
-    
+    private static Map<Locale, BibleNames> localizedBibleNames = new HashMap<Locale, BibleNames>();
+
     /** English BibleNames, or null when using the program's default locale */
     private static BibleNames englishBibleNames;
-    
+
     static {
         for (BibleBook book : BibleBook.values()) {
             osisMap.put(BookName.normalize(book.getOSIS(), Locale.ENGLISH), book);

--- a/src/main/java/org/crosswire/jsword/versification/BibleInfo.java
+++ b/src/main/java/org/crosswire/jsword/versification/BibleInfo.java
@@ -164,7 +164,7 @@ public final class BibleInfo {
      * @param verse
      *            The verse to convert
      * @return The ordinal number of verses
-     * @deprecated use {@link Versification#getOrdinal()} instead
+     * @deprecated use {@link Versification#getOrdinal(Verse)} instead
      */
     @Deprecated
     public static int getOrdinal(Verse verse) {
@@ -193,10 +193,10 @@ public final class BibleInfo {
      * <li>...</li>
      * </ul>
      *
-     * @param verse
-     *            The verse to convert
-     * @return The ordinal number of verses
-     * @deprecated use {@link Versification#getTestamentOrdinal()} instead
+     * @param ordinal
+     *            The ordinal number of the Verse
+     * @return The ordinal number of the verse in its testament
+     * @deprecated use {@link Versification#getTestamentOrdinal(int)} instead
      */
     @Deprecated
     public static int getTestamentOrdinal(int ordinal) {
@@ -475,7 +475,7 @@ public final class BibleInfo {
      * @return the number of verses
      * @exception NoSuchVerseException
      *                If either reference is illegal
-     * @deprecated Use {@link Versification#subtract(Verse, Verse)} instead.
+     * @deprecated Use {@link Versification#distance(Verse, Verse) + 1} instead.
      */
     @Deprecated
     public static int verseCount(Verse verse1, Verse verse2) throws NoSuchVerseException {

--- a/src/main/java/org/crosswire/jsword/versification/BookName.java
+++ b/src/main/java/org/crosswire/jsword/versification/BookName.java
@@ -166,7 +166,7 @@ public final class BookName {
         }
 
         // or a short version
-        if (normalizedShortName.startsWith(normalizedName) || (normalizedShortName.length()>0 && normalizedName.startsWith(normalizedShortName))) {
+        if (normalizedShortName.startsWith(normalizedName) || (normalizedShortName.length() > 0 && normalizedName.startsWith(normalizedShortName))) {
             return true;
         }
 

--- a/src/main/java/org/crosswire/jsword/versification/SectionNames.java
+++ b/src/main/java/org/crosswire/jsword/versification/SectionNames.java
@@ -30,7 +30,7 @@ import org.crosswire.jsword.JSMsg;
  *      The copyright to this program is held by it's authors.
  * @author Joe Walker [joe at eireneh dot com]
  * @author DM Smith [dmsmith555 at yahoo dot com]
- * @deprecated Use {@link DivisonName} instead.
+ * @deprecated Use org.crosswire.jsword.versification.DivisonName instead.
  */
 @Deprecated
 public enum SectionNames {

--- a/src/main/java/org/crosswire/jsword/versification/Versification.java
+++ b/src/main/java/org/crosswire/jsword/versification/Versification.java
@@ -525,9 +525,9 @@ public class Versification implements ReferenceSystem, Serializable {
      * <li>...</li>
      * </ul>
      *
-     * @param verse
-     *            The verse to convert
-     * @return The ordinal number of verses
+     * @param ordinal
+     *            The ordinal number of the verse to convert
+     * @return The ordinal number of the Verse within its Testament
      */
     public int getTestamentOrdinal(int ordinal) {
         int nt_ordinal = otMaxOrdinal + 1;

--- a/src/main/java/org/crosswire/jsword/versification/system/Versifications.java
+++ b/src/main/java/org/crosswire/jsword/versification/system/Versifications.java
@@ -102,7 +102,7 @@ public class Versifications {
         if (SystemKJV.V11N_NAME.equals(name)) {
             return new SystemKJV();
         }
-        
+
         //then in alphabetical order, to ease the developer checking we have them all
         if (SystemCatholic.V11N_NAME.equals(name)) {
             return new SystemCatholic();
@@ -140,8 +140,7 @@ public class Versifications {
         if (SystemVulg.V11N_NAME.equals(name)) {
             return new SystemVulg();
         }
-        
-        
+
         return null;
     }
 


### PR DESCRIPTION
Clean up most Checkstyle complaints that are not bug complaints.
Fix all JavaDoc complaints.
Put non-public member variables at bottom of classes.
