### PR TITLE
JS-268 Compare modules using initials as well as description

### DIFF
--- a/src/main/java/org/crosswire/jsword/book/basic/AbstractBookMetaData.java
+++ b/src/main/java/org/crosswire/jsword/book/basic/AbstractBookMetaData.java
@@ -270,7 +270,7 @@ public abstract class AbstractBookMetaData implements BookMetaData {
         // The real bit ...
         BookMetaData that = (BookMetaData) obj;
 
-        return getBookCategory().equals(that.getBookCategory()) && getName().equals(that.getName());
+        return getBookCategory().equals(that.getBookCategory()) && getInitials().equals(that.getInitials()) && getName().equals(that.getName());
     }
 
     @Override
@@ -283,6 +283,9 @@ public abstract class AbstractBookMetaData implements BookMetaData {
      */
     public int compareTo(BookMetaData obj) {
         int result = this.getBookCategory().compareTo(obj.getBookCategory());
+        if (result == 0) {
+            result = this.getInitials().compareTo(obj.getInitials());
+        }
         if (result == 0) {
             result = this.getName().compareTo(obj.getName());
         }

--- a/src/main/java/org/crosswire/jsword/book/install/sword/AbstractSwordInstaller.java
+++ b/src/main/java/org/crosswire/jsword/book/install/sword/AbstractSwordInstaller.java
@@ -372,7 +372,7 @@ public abstract class AbstractSwordInstaller extends AbstractBookList implements
                         SwordBookMetaData sbmd = new SwordBookMetaData(buffer, internal);
                         sbmd.setDriver(fake);
                         Book book = new SwordBook(sbmd, null);
-                        entries.put(book.getName(), book);
+                        entries.put(book.getInitials()+book.getName(), book);
                     } catch (IOException ex) {
                         log.error("Failed to load config for entry: {}", internal, ex);
                     }

--- a/src/test/java/org/crosswire/jsword/book/BookMetaDataTest.java
+++ b/src/test/java/org/crosswire/jsword/book/BookMetaDataTest.java
@@ -21,6 +21,9 @@
 package org.crosswire.jsword.book;
 
 import junit.framework.TestCase;
+import org.crosswire.jsword.book.sword.SwordBookMetaData;
+
+import java.io.IOException;
 
 /**
  * JUnit Test.
@@ -50,6 +53,22 @@ public class BookMetaDataTest extends TestCase {
      */
     @Override
     protected void tearDown() {
+    }
+
+
+    public void testDifferentInitialsNotEqual() {
+        String kjvMetaData = "[KJV]\nDataPath=./modules/texts/ztext/kjv/\nModDrv=zText\nEncoding=UTF-8\nBlockType=BOOK\nCompressType=ZIP\nSourceType=OSIS\nLang=en\nVersion=2.3\nDescription=King James Version (1769) with Strongs Numbers and Morphology\nLCSH=Bible. English.\n";
+        // the only difference is the initials
+        String kjvaMetaData = "[KJVA]\nDataPath=./modules/texts/ztext/kjva/\nModDrv=zText\nEncoding=UTF-8\nBlockType=BOOK\nCompressType=ZIP\nSourceType=OSIS\nLang=en\nVersion=2.3\nDescription=King James Version (1769) with Strongs Numbers and Morphology\nLCSH=Bible. English.\n";
+        try {
+            BookMetaData bmKJV = new SwordBookMetaData(kjvMetaData.getBytes(), "KJV");
+            BookMetaData bmKJV2 = new SwordBookMetaData(kjvMetaData.getBytes(), "KJV");
+            BookMetaData bmKJVA = new SwordBookMetaData(kjvaMetaData.getBytes(), "KJVA");
+            assertTrue( "Same metadata should equal", bmKJV.equals(bmKJV2));
+            assertFalse("Different initials should not equal", bmKJV.equals(bmKJVA));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public void testVersion() {


### PR DESCRIPTION
Books initials should also be used in comparisons.  A problem was caused when attempting to install various modules with different initials but the same description e.g. KJVA & KJV and some from IBT
.
I retained the use of description in comparison and added initials.

This code has been in use in the last release of And Bible for a month or so with no apparent problems.
