### PR TITLE
Adding a job ID to JSword

### DIFF
--- a/src/main/java/org/crosswire/common/progress/Job.java
+++ b/src/main/java/org/crosswire/common/progress/Job.java
@@ -20,20 +20,15 @@
  */
 package org.crosswire.common.progress;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-
 import org.crosswire.common.util.NetUtil;
 import org.crosswire.common.util.PropertyMap;
 import org.crosswire.jsword.JSMsg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
 
 /**
  * A Generic method of keeping track of Threads and monitoring their progress.
@@ -53,8 +48,9 @@ public final class Job implements Progress {
      * @param worker
      *            Optional thread to use in request to stop worker
      */
-    protected Job(String jobName, Thread worker) {
+    protected Job(String jobID, String jobName, Thread worker) {
         this.jobName = jobName;
+        this.jobID = jobID;
         this.workerThread = worker;
         this.listeners = new ArrayList<WorkListener>();
         this.cancelable = workerThread != null;
@@ -499,6 +495,7 @@ public final class Job implements Progress {
      */
     private String jobName;
 
+    private final String jobID;
     /**
      * Optional thread to monitor progress
      */
@@ -538,6 +535,13 @@ public final class Job implements Progress {
      * People that want to know about "cancelable" changes
      */
     private List<WorkListener> listeners;
+
+    /**
+     * The Job ID associated with this job
+     */
+    public String getJobID() {
+        return jobID;
+    }
 
     /**
      * So we can fake progress for Jobs that don't tell us how they are doing

--- a/src/main/java/org/crosswire/common/progress/JobManager.java
+++ b/src/main/java/org/crosswire/common/progress/JobManager.java
@@ -20,14 +20,15 @@
  */
 package org.crosswire.common.progress;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JobManager is responsible for creating jobs and informing listeners about the
@@ -82,7 +83,7 @@ public final class JobManager {
      * @param jobName the name of the Job
      */
     public static Progress createJob(String jobName) {
-        return createJob(jobName, null);
+        return createJob(UUID.randomUUID().toString(), jobName, null);
     }
 
     /**
@@ -91,8 +92,8 @@ public final class JobManager {
      * @param jobName the name of the Job
      * @param workerThread the thread on which this job runs
      */
-    public static Progress createJob(String jobName, Thread workerThread) {
-        Progress job = new Job(jobName, workerThread);
+    public static Progress createJob(String jobID, String jobName, Thread workerThread) {
+        Progress job = new Job(jobID, jobName, workerThread);
         jobs.add(job);
 
         log.debug("job starting: {}", job.getJobName());

--- a/src/main/java/org/crosswire/common/progress/Progress.java
+++ b/src/main/java/org/crosswire/common/progress/Progress.java
@@ -34,6 +34,10 @@ public interface Progress {
      * Indicate that the total amount of work is unknown.
      */
     int UNKNOWN = -1;
+    String INSTALL_BOOK = "INSTALL_BOOK-%s";
+    String RELOAD_BOOK_LIST = "RELOAD_BOOK_LIST";
+    String DOWNLOAD_SEARCH_INDEX = "DOWNLOAD_SEARCH_INDEX-%s";
+    String CREATE_INDEX = "CREATE_INDEX-%s";
 
     /**
      * Start the task measured from 0 to 100. It is the caller's responsibility to compute percentages.
@@ -70,6 +74,11 @@ public interface Progress {
      * @return the job name
      */
     String getJobName();
+
+    /**
+     * @return the unique ID of the job
+     */
+    String getJobID();
 
     /**
      * Gets the current ProgressMode. Builders of progress bars should use

--- a/src/main/java/org/crosswire/jsword/book/install/Installer.java
+++ b/src/main/java/org/crosswire/jsword/book/install/Installer.java
@@ -20,11 +20,11 @@
  */
 package org.crosswire.jsword.book.install;
 
-import java.net.URI;
-import java.util.List;
-
 import org.crosswire.jsword.book.Book;
 import org.crosswire.jsword.book.BookList;
+
+import java.net.URI;
+import java.util.List;
 
 /**
  * An interface that allows us to download from a specific source of Bible data.
@@ -111,8 +111,11 @@ public interface Installer extends BookList {
      * Download and install a book locally. The name should be one from an index
      * list retrieved from getIndex() or reloadIndex()
      * 
+     *
+     *
      * @param book
      *            The book to install
+     * @return the jobId that can be used to track progress
      */
     void install(final Book book) throws InstallException;
 

--- a/src/main/java/org/crosswire/jsword/book/install/sword/AbstractSwordInstaller.java
+++ b/src/main/java/org/crosswire/jsword/book/install/sword/AbstractSwordInstaller.java
@@ -20,6 +20,20 @@
  */
 package org.crosswire.jsword.book.install.sword;
 
+import com.ice.tar.TarEntry;
+import com.ice.tar.TarInputStream;
+import org.crosswire.common.progress.JobManager;
+import org.crosswire.common.progress.Progress;
+import org.crosswire.common.util.*;
+import org.crosswire.jsword.JSMsg;
+import org.crosswire.jsword.JSOtherMsg;
+import org.crosswire.jsword.book.*;
+import org.crosswire.jsword.book.install.InstallException;
+import org.crosswire.jsword.book.install.Installer;
+import org.crosswire.jsword.book.sword.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,37 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
-
-import org.crosswire.common.progress.JobManager;
-import org.crosswire.common.progress.Progress;
-import org.crosswire.common.util.CWProject;
-import org.crosswire.common.util.CollectionUtil;
-import org.crosswire.common.util.IOUtil;
-import org.crosswire.common.util.NetUtil;
-import org.crosswire.common.util.Reporter;
-import org.crosswire.jsword.JSMsg;
-import org.crosswire.jsword.JSOtherMsg;
-import org.crosswire.jsword.book.AbstractBookList;
-import org.crosswire.jsword.book.Book;
-import org.crosswire.jsword.book.BookDriver;
-import org.crosswire.jsword.book.BookException;
-import org.crosswire.jsword.book.BookFilter;
-import org.crosswire.jsword.book.BookFilterIterator;
-import org.crosswire.jsword.book.BookMetaData;
-import org.crosswire.jsword.book.BookSet;
-import org.crosswire.jsword.book.install.InstallException;
-import org.crosswire.jsword.book.install.Installer;
-import org.crosswire.jsword.book.sword.ConfigEntry;
-import org.crosswire.jsword.book.sword.SwordBook;
-import org.crosswire.jsword.book.sword.SwordBookDriver;
-import org.crosswire.jsword.book.sword.SwordBookMetaData;
-import org.crosswire.jsword.book.sword.SwordBookPath;
-import org.crosswire.jsword.book.sword.SwordConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.ice.tar.TarEntry;
-import com.ice.tar.TarInputStream;
 
 /**
  * The AbstractSwordInstaller provides for the common implementation of derived classes.
@@ -218,7 +201,7 @@ public abstract class AbstractSwordInstaller extends AbstractBookList implements
 
         // TRANSLATOR: Progress label indicating the installation of a book. {0} is a placeholder for the name of the book.
         String jobName = JSMsg.gettext("Installing book: {0}", sbmd.getName());
-        Progress job = JobManager.createJob(jobName, Thread.currentThread());
+        Progress job = JobManager.createJob(String.format(Progress.INSTALL_BOOK, book.getInitials()), jobName, Thread.currentThread());
 
         URI temp = null;
         try {
@@ -275,7 +258,7 @@ public abstract class AbstractSwordInstaller extends AbstractBookList implements
     public void reloadBookList() throws InstallException {
         // TRANSLATOR: Progress label for downloading one or more files.
         String jobName = JSMsg.gettext("Downloading files");
-        Progress job = JobManager.createJob(jobName, Thread.currentThread());
+        Progress job = JobManager.createJob(Progress.RELOAD_BOOK_LIST, jobName, Thread.currentThread());
         job.beginJob(jobName);
 
         try {
@@ -296,7 +279,7 @@ public abstract class AbstractSwordInstaller extends AbstractBookList implements
     public void downloadSearchIndex(Book book, URI localDest) throws InstallException {
         // TRANSLATOR: Progress label for downloading one or more files.
         String jobName = JSMsg.gettext("Downloading files");
-        Progress job = JobManager.createJob(jobName, Thread.currentThread());
+        Progress job = JobManager.createJob(String.format(Progress.DOWNLOAD_SEARCH_INDEX, book.getInitials()), jobName, Thread.currentThread());
         job.beginJob(jobName);
 
         try {

--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneIndex.java
@@ -20,24 +20,13 @@
  */
 package org.crosswire.jsword.index.lucene;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.queryParser.QueryParser;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Searcher;
-import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.Version;
@@ -47,29 +36,26 @@ import org.crosswire.common.util.FileUtil;
 import org.crosswire.common.util.NetUtil;
 import org.crosswire.common.util.Reporter;
 import org.crosswire.jsword.JSMsg;
-import org.crosswire.jsword.book.Book;
-import org.crosswire.jsword.book.BookData;
-import org.crosswire.jsword.book.BookException;
-import org.crosswire.jsword.book.FeatureType;
-import org.crosswire.jsword.book.OSISUtil;
+import org.crosswire.jsword.book.*;
 import org.crosswire.jsword.index.AbstractIndex;
 import org.crosswire.jsword.index.IndexManager;
 import org.crosswire.jsword.index.IndexPolicy;
 import org.crosswire.jsword.index.IndexStatus;
 import org.crosswire.jsword.index.lucene.analysis.LuceneAnalyzer;
 import org.crosswire.jsword.index.search.SearchModifier;
-import org.crosswire.jsword.passage.AbstractPassage;
-import org.crosswire.jsword.passage.Key;
-import org.crosswire.jsword.passage.NoSuchKeyException;
-import org.crosswire.jsword.passage.NoSuchVerseException;
-import org.crosswire.jsword.passage.PassageTally;
-import org.crosswire.jsword.passage.Verse;
-import org.crosswire.jsword.passage.VerseFactory;
+import org.crosswire.jsword.passage.*;
 import org.crosswire.jsword.versification.Versification;
 import org.crosswire.jsword.versification.system.Versifications;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Implement the SearchEngine using Lucene as the search engine.
@@ -168,7 +154,7 @@ public class LuceneIndex extends AbstractIndex implements Closeable {
 
         // TRANSLATOR: Progress label indicating the start of indexing. {0} is a placeholder for the book's short name.
         String jobName = JSMsg.gettext("Creating index. Processing {0}", book.getInitials());
-        Progress job = JobManager.createJob(jobName, Thread.currentThread());
+        Progress job = JobManager.createJob(String.format(Progress.CREATE_INDEX, book.getInitials()), jobName, Thread.currentThread());
         job.beginJob(jobName);
 
         IndexStatus finalStatus = IndexStatus.UNDONE;

--- a/src/test/java/org/crosswire/common/progress/JobTest.java
+++ b/src/test/java/org/crosswire/common/progress/JobTest.java
@@ -20,11 +20,12 @@
  */
 package org.crosswire.common.progress;
 
+import junit.framework.TestCase;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-
-import junit.framework.TestCase;
+import java.util.UUID;
 
 /**
  * JUnit Test.
@@ -64,7 +65,7 @@ public class JobTest extends TestCase {
         assertEquals(100, job.getWork());
         assertEquals(job.isCancelable(), false);
 
-        job = JobManager.createJob(WIBBLE, Thread.currentThread());
+        job = JobManager.createJob(UUID.randomUUID().toString(), WIBBLE, Thread.currentThread());
         job.beginJob(WIBBLE);
         assertEquals(WIBBLE, job.getJobName());
         assertEquals(false, job.isFinished());
@@ -89,7 +90,7 @@ public class JobTest extends TestCase {
         assertEquals(100, job.getWork());
         // assertEquals(false, job.isCancelable());
 
-        job = JobManager.createJob(WIBBLE, Thread.currentThread());
+        job = JobManager.createJob(UUID.randomUUID().toString(), WIBBLE, Thread.currentThread());
         job.beginJob(WIBBLE, uri);
         assertEquals(WIBBLE, job.getJobName());
         assertEquals(false, job.isFinished());


### PR DESCRIPTION
Adding a JOB ID, so that webapps can effectively get back to a job in progress (especially now that's it's synchronous). Webapps don't really want to use listeners as they might stay around for a long time.
