### PR TITLE
Allow load of mapping data to be requested for a v11n

### DIFF
--- a/src/main/java/org/crosswire/jsword/versification/VersificationsMapper.java
+++ b/src/main/java/org/crosswire/jsword/versification/VersificationsMapper.java
@@ -171,10 +171,20 @@ public class VersificationsMapper {
         return finalKey;
     }
 
+    /** 
+     * Call this to ensure mapping data is loaded (maybe for newly installed books).  
+     * Should normally be called from a background thread, not the ui thread.
+
+     * @param versification the versification we want to load mapping data for
+     */
+    public void ensureMappingDataLoaded(Versification versification) {
+        ensure(versification);
+    }
+    
     /**
      * Reads the mapping from file if it does not exist
      *
-     * @param versification the versification we want to look
+     * @param versification the versification we want to load
      */
     private void ensure(final Versification versification) {
         if (MAPPERS.containsKey(versification)) {


### PR DESCRIPTION
A simple public method opening up access to trigger load of mapping data.

This gives And Bible the ability to force mapping data for newly installed modules to be loaded in a background thread.  
