### PR TITLE
Allow selection of RangedPassage as the default PassageType

### DIFF
--- a/src/main/java/org/crosswire/jsword/passage/PassageType.java
+++ b/src/main/java/org/crosswire/jsword/passage/PassageType.java
@@ -98,12 +98,12 @@ public enum PassageType {
             if (passage == null || passage.length() == 0) {
                 return createEmptyPassage(v11n);
             }
-            return new PassageTally(v11n, passage, basis);
+            return new RangedPassage(v11n, passage, basis);
         }
 
         @Override
         public Passage createEmptyPassage(Versification v11n) {
-            return new PassageTally(v11n);
+            return new RangedPassage(v11n);
         }
     },
 


### PR DESCRIPTION
PassageTally was selectable as the default via PassageType.MIX or TALLY, whereas RangePassage was not selectable.  This change allows RangePassage to be selected as the default via MIX.
