### PR TITLE
Made empty passage constructors public.

### DIFF
--- a/src/main/java/org/crosswire/jsword/passage/BitwisePassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/BitwisePassage.java
@@ -58,7 +58,7 @@ public class BitwisePassage extends AbstractPassage {
      * @param v11n
      *            The Versification to which this Passage belongs.
      */
-    protected BitwisePassage(Versification v11n) {
+    public BitwisePassage(Versification v11n) {
         super(v11n);
         store = new BitSet(v11n.maximumOrdinal() + 1);
     }

--- a/src/main/java/org/crosswire/jsword/passage/DistinctPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/DistinctPassage.java
@@ -51,7 +51,7 @@ public class DistinctPassage extends AbstractPassage {
      * @param v11n
      *            The Versification to which this Passage belongs.
      */
-    protected DistinctPassage(Versification v11n) {
+    public DistinctPassage(Versification v11n) {
         super(v11n);
     }
 

--- a/src/main/java/org/crosswire/jsword/passage/PassageTally.java
+++ b/src/main/java/org/crosswire/jsword/passage/PassageTally.java
@@ -124,13 +124,13 @@ public class PassageTally extends AbstractPassage {
      * @throws NoSuchVerseException
      *             If refs is invalid
      */
-    public PassageTally(Versification v11n, String refs, Key basis) throws NoSuchVerseException {
+    protected PassageTally(Versification v11n, String refs, Key basis) throws NoSuchVerseException {
         super(v11n, refs);
         board = new int[v11n.maximumOrdinal() + 1];
         addVerses(refs, basis);
     }
 
-    public PassageTally(Versification v11n, String refs) throws NoSuchVerseException {
+    protected PassageTally(Versification v11n, String refs) throws NoSuchVerseException {
         this(v11n, refs, null);
     }
 

--- a/src/main/java/org/crosswire/jsword/passage/RangedPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/RangedPassage.java
@@ -64,7 +64,7 @@ public class RangedPassage extends AbstractPassage {
      * @param refSystem
      *            The Versification to which this Passage belongs.
      */
-    protected RangedPassage(Versification refSystem) {
+    public RangedPassage(Versification refSystem) {
         super(refSystem);
         store = new TreeSet<Key>();
     }

--- a/src/main/java/org/crosswire/jsword/passage/ReadOnlyPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/ReadOnlyPassage.java
@@ -45,7 +45,7 @@ final class ReadOnlyPassage implements Passage {
      * @param ignore
      *            Do we throw up if someone tries to change us
      */
-    protected ReadOnlyPassage(Passage ref, boolean ignore) {
+    public ReadOnlyPassage(Passage ref, boolean ignore) {
         this.ref = ref;
         this.ignore = ignore;
     }

--- a/src/main/java/org/crosswire/jsword/passage/SynchronizedPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/SynchronizedPassage.java
@@ -43,7 +43,7 @@ final class SynchronizedPassage implements Passage {
      * @param ref
      *            The real Passage
      */
-    protected SynchronizedPassage(Passage ref) {
+    public SynchronizedPassage(Passage ref) {
         this.ref = ref;
     }
 


### PR DESCRIPTION
This allows one to create empty specific types of Passages. This is needed for time/space optimizations when the application is controlling what is created and how it is used.
