### PR TITLE
Avoid exception if missing http Content-Length header

### DIFF
--- a/src/main/java/org/crosswire/common/util/WebResource.java
+++ b/src/main/java/org/crosswire/common/util/WebResource.java
@@ -326,6 +326,11 @@ public class WebResource {
      */
     private int getHeaderAsInt(HttpResponse response, String field) {
         Header header = response.getFirstHeader(field);
+        // If there is no matching header in the message null is returned.
+        if (header==null) {
+            return 0;
+        }
+        
         String value = header.getValue();
         try {
             return Integer.parseInt(value);


### PR DESCRIPTION
This problem rarely occurs but it was in AB error logs 4 times in February.
