### PR TITLE
Removing line that breaks Joel.4.1-Joel.4.21=Joel.3.1-Joel.3.21. These a...

### DIFF
--- a/src/main/java/org/crosswire/jsword/versification/VersificationToKJVMapper.java
+++ b/src/main/java/org/crosswire/jsword/versification/VersificationToKJVMapper.java
@@ -236,13 +236,6 @@ public class VersificationToKJVMapper {
                 }
 
                 Verse rightVerse = (Verse) kjvIter.next();
-
-                // Identity mapping is the default
-                // We might want to report this
-                if (leftVerse.getVerse() == rightVerse.getVerse()) {
-                    continue;
-                }
-
                 QualifiedKey kjvKey = new QualifiedKey(rightVerse);
 
                 // When the lists are of lengths differing by one


### PR DESCRIPTION
...re not identity mappings. Furthermore, identity mappings have to be mapped to preserve verse parts stored in the qualified keys, rather than the verse

There are two issues with these lines:

1- it breaks when two mappings map to the same verses in different chapters (see ref in commit message) - observed as breaking Joel 4 in STEP

2- the qualified key may be storing extra information that would get lost. (assumed for code reading).

As a result of 2-, it is best to remove the line.
Chris
