### PR TITLE
Add unit test for verse 0 mapping

### DIFF
--- a/src/main/resources/org/crosswire/jsword/versification/Synodal.properties
+++ b/src/main/resources/org/crosswire/jsword/versification/Synodal.properties
@@ -1,4 +1,4 @@
-# English KJV = Russian Synodal
+# Russian Synodal = English KJV
 # adapted from XulSword  https://xulsword.googlecode.com/svn/trunk/Cpp/src/include/versemaPs.h on 30/4/2013
 # corrections & half-verses & Psalm titles & colophons added by TyndaleSTEP at gmail dot com DIB 2013
 #

--- a/src/test/java/org/crosswire/jsword/versification/VersificationsMapperTest.java
+++ b/src/test/java/org/crosswire/jsword/versification/VersificationsMapperTest.java
@@ -24,6 +24,7 @@ import org.crosswire.jsword.passage.*;
 import org.crosswire.jsword.versification.system.SystemCatholic;
 import org.crosswire.jsword.versification.system.SystemCatholic2;
 import org.crosswire.jsword.versification.system.SystemKJV;
+import org.crosswire.jsword.versification.system.SystemSynodal;
 import org.crosswire.jsword.versification.system.Versifications;
 import org.junit.Test;
 
@@ -41,6 +42,7 @@ public class VersificationsMapperTest {
     private static final Versification KJV = Versifications.instance().getVersification(SystemKJV.V11N_NAME);
     private static final Versification CATHOLIC = Versifications.instance().getVersification(SystemCatholic.V11N_NAME);
     private static final Versification CATHOLIC2 = Versifications.instance().getVersification(SystemCatholic2.V11N_NAME);
+    private static final Versification SYNODAL = Versifications.instance().getVersification(SystemSynodal.V11N_NAME);
 
     @Test
     public void testTwoStepVersification() throws NoSuchVerseException {
@@ -74,6 +76,16 @@ public class VersificationsMapperTest {
     public void testSingleStepFromKJV() throws NoSuchVerseException {
         doTest(KJV, "Exod.1.2", CATHOLIC, "Gen.1.1");
         doTest(KJV, "Exod.1.3", CATHOLIC, "Gen.1.2-Gen.1.3");
+    }
+
+    @Test
+    public void testMapVerseZero() throws NoSuchVerseException {
+        doTest(KJV, "Gen.1.0", KJV, "Gen.1.0");
+        doTest(KJV, "Gen.1.0", SYNODAL, "Gen.1.0");
+        doTest(KJV, "Ps.50.0", KJV, "Ps.50.0");
+        doTest(KJV, "Ps.50.0", CATHOLIC, "Ps.50.0");
+        doTest(KJV, "Ps.50.0", SYNODAL, "Ps.49.1");
+        doTest(SYNODAL, "Ps.49.1", KJV, "Ps.50.0-Ps.50.1");
     }
 
     /**


### PR DESCRIPTION
Thanks for fixing the verse 0 mapping issue.  I wanted to add a unit test for this functionality to keep it working because I think AB is the only app that depends on this.
I also fixed a comment that confused me for a while because the v11ns were reversed.
