### PR TITLE
Allow ranges anywhere in the search string

### DIFF
--- a/src/main/java/org/crosswire/jsword/index/lucene/LuceneQueryBuilder.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/LuceneQueryBuilder.java
@@ -68,7 +68,7 @@ public final class LuceneQueryBuilder implements QueryBuilder {
         if (rangeMatcher.find()) {
             rangeModifier = rangeMatcher.group(1);
             range = new RangeQuery(rangeMatcher.group(2));
-            sought = sought.substring(rangeMatcher.end());
+            sought = sought.replace(rangeMatcher.group(), " ");
         }
 
         // Look for a blur ~n
@@ -104,7 +104,7 @@ public final class LuceneQueryBuilder implements QueryBuilder {
      * leading [] (but not containing a [ or ]), with a + or - optional prefix,
      * perhaps surrounded by whitespace.
      */
-    private static final Pattern RANGE_PATTERN = Pattern.compile("^\\s*([-+]?)\\[([^\\[\\]]+)\\]\\s*");
+    private static final Pattern RANGE_PATTERN = Pattern.compile("\\s*([-+]?)\\[([^\\[\\]]+)\\]\\s*");
 
     /**
      * The pattern of a blur. A '~', optionally followed by a number,


### PR DESCRIPTION
Small change to allow ranges to be specified anywhere in the string, rather than just the start.
