### PR TITLE
Fix to prevent invalid keys from being returned. Previously keys such as...

### DIFF
--- a/src/main/java/org/crosswire/jsword/passage/AbstractPassage.java
+++ b/src/main/java/org/crosswire/jsword/passage/AbstractPassage.java
@@ -506,6 +506,12 @@ public abstract class AbstractPassage implements Passage {
      * @see org.crosswire.jsword.passage.Key#addAll(org.crosswire.jsword.passage.Key)
      */
     public void addAll(Key key) {
+        //check for key empty. This avoids the AIOBounds with that.getVerseAt, during event firing
+        if (key.isEmpty()) {
+            //nothing to add
+            return;
+        }
+
         optimizeWrites();
         raiseEventSuppresion();
         raiseNormalizeProtection();

--- a/src/main/java/org/crosswire/jsword/passage/Verse.java
+++ b/src/main/java/org/crosswire/jsword/passage/Verse.java
@@ -33,6 +33,8 @@ import org.crosswire.jsword.versification.BibleBook;
 import org.crosswire.jsword.versification.BibleNames;
 import org.crosswire.jsword.versification.Versification;
 import org.crosswire.jsword.versification.system.Versifications;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Verse is a pointer to a single verse. Externally its unique identifier is
@@ -303,7 +305,17 @@ public final class Verse implements VerseKey<Verse> {
         if (v11n.equals(newVersification)) {
             return this;
         }
-        return new Verse(newVersification, book, chapter, verse);
+
+        try {
+            //check the v11n supports this key, otherwise this leads to all sorts of issues
+            if (newVersification.validate(book, chapter, verse, true)) {
+                return new Verse(newVersification, book, chapter, verse);
+            }
+        } catch(NoSuchVerseException ex) {
+            //will never happen
+            log.error("Contract for validate was changed to thrown an exception when silent mode is true", ex);
+        }
+        return null;
     }
 
     /**
@@ -632,6 +644,8 @@ public final class Verse implements VerseKey<Verse> {
      * a.xy.asdf.qr
      */
     private String subIdentifier;
+
+    private static final Logger log = LoggerFactory.getLogger(Verse.class);
 
     /**
      * To make serialization work across new versions

--- a/src/main/java/org/crosswire/jsword/passage/VerseRange.java
+++ b/src/main/java/org/crosswire/jsword/passage/VerseRange.java
@@ -111,7 +111,13 @@ public final class VerseRange implements VerseKey<VerseRange> {
             return this;
         }
         Verse newStart = start.reversify(newVersification);
+        if(newStart == null) {
+            return null;
+        }
         Verse newEnd = end.reversify(newVersification);
+        if(newEnd == null) {
+            return null;
+        }
         return new VerseRange(newVersification, newStart, newEnd);
     }
 

--- a/src/main/java/org/crosswire/jsword/versification/QualifiedKey.java
+++ b/src/main/java/org/crosswire/jsword/versification/QualifiedKey.java
@@ -23,6 +23,7 @@ package org.crosswire.jsword.versification;
 import org.crosswire.jsword.passage.Verse;
 import org.crosswire.jsword.passage.VerseKey;
 import org.crosswire.jsword.passage.VerseRange;
+import org.crosswire.jsword.versification.system.Versifications;
 
 /**
  * A QualifiedKey represents the various left and right sides of a map entry.
@@ -38,10 +39,10 @@ import org.crosswire.jsword.passage.VerseRange;
  * The mapping can indicate a part of a verse. This is an internal implementation detail of the Versification mapping code.
  * Here it is used to distinguish one QualifiedKey from another in equality tests and in containers.
  * </p>
- * 
- * @see gnu.lgpl.License for license details.<br>
- *      The copyright to this program is held by it's authors.
+ *
  * @author chrisburrell
+ * @see gnu.lgpl.License for license details.<br>
+ * The copyright to this program is held by it's authors.
  */
 public final class QualifiedKey {
     /**
@@ -75,9 +76,9 @@ public final class QualifiedKey {
                 return q != null && q.getSectionName() != null ? q.getSectionName() : "Missing section name";
             }
         };
+
         /**
-         * @param q
-         *            the QualifiedKey that this describes
+         * @param q the QualifiedKey that this describes
          * @return The description for the qualified key
          */
         public abstract String getDescription(QualifiedKey q);
@@ -86,7 +87,7 @@ public final class QualifiedKey {
 
     /**
      * Construct a QualifiedKey from a Verse.
-     * 
+     *
      * @param key the verse from which to create this QualifiedKey
      */
     public QualifiedKey(Verse key) {
@@ -96,7 +97,7 @@ public final class QualifiedKey {
 
     /**
      * Construct a QualifiedKey from a Verse.
-     * 
+     *
      * @param key the verse range from which to create this QualifiedKey
      */
     public QualifiedKey(VerseRange key) {
@@ -115,7 +116,6 @@ public final class QualifiedKey {
     /**
      * Constructs the QualifiedKey with the ABSENT_IN_LEFT qualifier.
      * This really means that there are no fields in this QualifiedKey.
-     *
      */
     public QualifiedKey() {
         this.absentType = Qualifier.ABSENT_IN_LEFT;
@@ -123,7 +123,7 @@ public final class QualifiedKey {
 
     /**
      * Create a QualifiedKey from a Verse or a VerseRange.
-     * 
+     *
      * @param k the Verse or VerseRange
      * @return the created QualifiedKey
      * @throws ClassCastException
@@ -163,7 +163,7 @@ public final class QualifiedKey {
 
     /**
      * A QualifiedKey is whole if it does not split part of a reference.
-     * 
+     *
      * @return whether this QualifiedKey has a whole reference
      */
     public boolean isWhole() {
@@ -178,7 +178,7 @@ public final class QualifiedKey {
      * This is a potentially dangerous operation that does no mapping
      * from one versification to another. Use it only when it is known
      * to be safe.
-     * 
+     *
      * @param target The target versification
      * @return The reversified QualifiedKey
      */
@@ -188,7 +188,17 @@ public final class QualifiedKey {
             return this;
         }
 
-        return create(qualifiedKey.reversify(target));
+        final VerseKey reversifiedKey = qualifiedKey.reversify(target);
+        if (reversifiedKey != null) {
+            return create(reversifiedKey);
+        }
+
+        if (target.getName().equals(Versifications.DEFAULT_V11N)) {
+            //then we're absent in KJV
+            return new QualifiedKey(qualifiedKey.getOsisID());
+        }
+        return new QualifiedKey();
+
     }
 
     @Override
@@ -211,8 +221,8 @@ public final class QualifiedKey {
     public int hashCode() {
         // Use a prime number in case one of the values is not around
         return (this.qualifiedKey == null ? 17 : qualifiedKey.hashCode())
-             + (this.absentType == null ? 13 : this.absentType.ordinal())
-             + (this.sectionName == null ? 19 : this.sectionName.hashCode());
+                + (this.absentType == null ? 13 : this.absentType.ordinal())
+                + (this.sectionName == null ? 19 : this.sectionName.hashCode());
     }
 
     @Override
@@ -220,14 +230,15 @@ public final class QualifiedKey {
         if (obj instanceof QualifiedKey) {
             final QualifiedKey otherKey = (QualifiedKey) obj;
             return this.getAbsentType() == otherKey.getAbsentType()
-                && bothNullOrEqual(this.sectionName, otherKey.sectionName)
-                && bothNullOrEqual(this.qualifiedKey, otherKey.qualifiedKey);
+                    && bothNullOrEqual(this.sectionName, otherKey.sectionName)
+                    && bothNullOrEqual(this.qualifiedKey, otherKey.qualifiedKey);
         }
         return false;
     }
 
     /**
      * Allow override of the key, particular useful if we're constructing in 2 stages like the offset mechanism
+     *
      * @param key the new key
      */
     private void setKey(final Verse key) {
@@ -237,6 +248,7 @@ public final class QualifiedKey {
 
     /**
      * Allow override of the key, particular useful if we're constructing in 2 stages like the offset mechanism
+     *
      * @param key the new key
      */
     private void setKey(final VerseRange key) {
@@ -250,6 +262,7 @@ public final class QualifiedKey {
 
     /**
      * Determine whether two objects are equal, allowing nulls
+     *
      * @param x
      * @param y
      * @return true if both are null or the two are equal

--- a/src/main/java/org/crosswire/jsword/versification/Versification.java
+++ b/src/main/java/org/crosswire/jsword/versification/Versification.java
@@ -981,9 +981,33 @@ public class Versification implements ReferenceSystem, Serializable {
      *                If the reference is illegal
      */
     public void validate(BibleBook book, int chapter, int verse) throws NoSuchVerseException {
+        validate(book, chapter, verse, false);
+    }
 
+    /**
+     * Does the following represent a real verse?. It is code like this that
+     * makes me wonder if I18 is done well/worth doing. All this code does is
+     * check if the numbers are valid, but the exception handling code is huge
+     * :(
+     *
+     * @param book
+     *            The book part of the reference.
+     * @param chapter
+     *            The chapter part of the reference.
+     * @param verse
+     *            The verse part of the reference.
+     * @param silent
+     *            true to indicate we do not want to throw an exception
+     * @return true if validation was succesful
+     * @exception NoSuchVerseException
+     *                If the reference is illegal and silent was false
+     */
+    public boolean validate(BibleBook book, int chapter, int verse, boolean silent) throws NoSuchVerseException {
         // Check the book
         if (book == null) {
+            if(silent) {
+                return false;
+            }
             // TRANSLATOR: The user did not supply a book for a verse reference.
             throw new NoSuchVerseException(JSOtherMsg.lookupText("Book must not be null"));
         }
@@ -991,6 +1015,9 @@ public class Versification implements ReferenceSystem, Serializable {
         // Check the chapter
         int maxChapter = getLastChapter(book);
         if (chapter < 0 || chapter > maxChapter) {
+            if(silent) {
+                return false;
+            }
             // TRANSLATOR: The user supplied a chapter that was out of bounds. This tells them what is allowed.
             // {0} is the lowest value that is allowed. This is always 0.
             // {1,number,integer} is the place holder for the highest chapter number in the book. The format is special in that it will present it in the user's preferred format.
@@ -998,12 +1025,15 @@ public class Versification implements ReferenceSystem, Serializable {
             // {3,number,integer} is a placeholder for the chapter number that the user gave.
             throw new NoSuchVerseException(JSMsg.gettext("Chapter should be between {0} and {1,number,integer} for {2} (given {3,number,integer}).",
                     Integer.valueOf(0), Integer.valueOf(maxChapter), getPreferredName(book), Integer.valueOf(chapter)
-                    ));
+            ));
         }
 
         // Check the verse
         int maxVerse = getLastVerse(book, chapter);
         if (verse < 0 || verse > maxVerse) {
+            if(silent) {
+                return false;
+            }
             // TRANSLATOR: The user supplied a verse number that was out of bounds. This tells them what is allowed.
             // {0} is the lowest value that is allowed. This is always 0.
             // {1,number,integer} is the place holder for the highest verse number in the chapter. The format is special in that it will present it in the user's preferred format.
@@ -1014,6 +1044,7 @@ public class Versification implements ReferenceSystem, Serializable {
                     Integer.valueOf(0), Integer.valueOf(maxVerse), getPreferredName(book), Integer.valueOf(chapter), Integer.valueOf(verse)
                     ));
         }
+        return true;
     }
 
     /**

--- a/src/main/java/org/crosswire/jsword/versification/VersificationToKJVMapper.java
+++ b/src/main/java/org/crosswire/jsword/versification/VersificationToKJVMapper.java
@@ -481,8 +481,13 @@ public class VersificationToKJVMapper {
          if (vr.getCardinality() > 1) {
              end = versification.add(start, vr.getCardinality() - 1);
          }
-         VerseRange newvr = new VerseRange(versification, start, end);
-         return new QualifiedKey(newvr);
+
+        if(start == null || end == null) {
+            hasErrors = true;
+            LOGGER.error("Verse range with offset did not map to correct range in target versification. This mapping will be set to an empty unmapped key.");
+        }
+
+         return start != null && end != null ? new QualifiedKey(new VerseRange(versification, start, end)) : new QualifiedKey(versesKey);
     }
 
     /**

--- a/src/main/java/org/crosswire/jsword/versification/VersificationsMapper.java
+++ b/src/main/java/org/crosswire/jsword/versification/VersificationsMapper.java
@@ -135,7 +135,11 @@ public final class VersificationsMapper {
             // and assume that it maps directly on to the KJV,
             // and thereby continue with the process
             kjvVerses = new ArrayList<QualifiedKey>();
-            kjvVerses.add(new QualifiedKey(v.reversify(KJV)));
+            final Verse reversifiedVerse = v.reversify(KJV);
+            //check that the key actually exists
+            if(reversifiedVerse != null) {
+                kjvVerses.add(new QualifiedKey(reversifiedVerse));
+            }
         } else {
             //we need qualified keys back, so as to preserve parts
             kjvVerses = mapper.map(new QualifiedKey(v));
@@ -161,7 +165,11 @@ public final class VersificationsMapper {
         // well.
         VerseKey finalKeys = new RangedPassage(targetVersification);
         for (QualifiedKey qualifiedKey : kjvVerses) {
-            finalKeys.addAll(targetMapper.unmap(qualifiedKey));
+            final VerseKey verseKey = targetMapper.unmap(qualifiedKey);
+            if(verseKey != null) {
+                //verse key exists in the target versification
+                finalKeys.addAll(verseKey);
+            }
         }
         return finalKeys;
     }
@@ -179,7 +187,11 @@ public final class VersificationsMapper {
         final VerseKey finalKeys = new RangedPassage(targetVersification);
         for (QualifiedKey qualifiedKey : kjvVerses) {
             if (qualifiedKey.getKey() != null) {
-                finalKeys.addAll(qualifiedKey.reversify(targetVersification).getKey());
+                final VerseKey key = qualifiedKey.reversify(targetVersification).getKey();
+                if(key != null) {
+                    //verse key exists in target versification
+                    finalKeys.addAll(key);
+                }
             }
         }
         return finalKeys;


### PR DESCRIPTION
... 1Ti 6:1 were returned attached to the Leningrad versification

Previously, you would get keys attached to the Leningrad versification referrnig to 1Tim 6 and such like. This was causing all sorts of issues due to the versiifications private fields not quite matching the ordinals represented in the VerseKey

Chris
