### PR TITLE
Adding hebrew analyser [not necessarily for inclusion - just to compare ]

### DIFF
--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewLuceneAnalyzer.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewLuceneAnalyzer.java
@@ -1,0 +1,69 @@
+/**
+ * Distribution License:
+ * JSword is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License, version 2.1 or later
+ * as published by the Free Software Foundation. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * The License is available on the internet at:
+ *       http://www.gnu.org/copyleft/lgpl.html
+ * or by writing to:
+ *      Free Software Foundation, Inc.
+ *      59 Temple Place - Suite 330
+ *      Boston, MA 02111-1307, USA
+ *
+ * Copyright: 2007
+ *     The copyright to this program is held by it's authors.
+ *
+ */
+package org.crosswire.jsword.index.lucene.analysis;
+
+import org.apache.lucene.analysis.StopFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.el.GreekAnalyzer;
+import org.apache.lucene.analysis.el.GreekLowerCaseFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Analyzer that removes the accents from the Hebrew text
+ * 
+ * @see gnu.lgpl.License for license details.<br>
+ *      The copyright to this program is held by it's authors.
+ * @author Sijo Cherian [sijocherian at yahoo dot com]
+ */
+public class HebrewLuceneAnalyzer extends AbstractBookAnalyzer {
+    public HebrewLuceneAnalyzer() {
+
+    }
+
+    @Override
+    public TokenStream tokenStream(String fieldName, Reader reader) {
+        TokenStream result = new StandardTokenizer(matchVersion, reader);
+        result = new HebrewPointingFilter(result);
+
+        return result;
+    }
+
+
+    @Override
+    public TokenStream reusableTokenStream(String fieldName, Reader reader) throws IOException {
+        SavedStreams streams = (SavedStreams) getPreviousTokenStream();
+        if (streams == null) {
+            streams = new SavedStreams(new StandardTokenizer(matchVersion, reader));
+            streams.setResult(new HebrewPointingFilter(streams.getResult()));
+
+            setPreviousTokenStream(streams);
+        } else {
+            streams.getSource().reset(reader);
+        }
+        return streams.getResult();
+    }
+
+    private final Version matchVersion = Version.LUCENE_29;
+}

--- a/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewPointingFilter.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/analysis/HebrewPointingFilter.java
@@ -1,0 +1,67 @@
+package org.crosswire.jsword.index.lucene.analysis;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.TermAttribute;
+
+import java.io.IOException;
+
+/**
+ * Simply removes pointing from the given term
+ */
+public class HebrewPointingFilter extends AbstractBookTokenFilter {
+    private final TermAttribute termAtt;
+
+    /**
+     * @param input the token stream
+     */
+    public HebrewPointingFilter(final TokenStream input) {
+        super(input);
+        this.termAtt = addAttribute(TermAttribute.class);
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+        if (this.input.incrementToken()) {
+            final String unaccentedForm = unPoint(this.termAtt.term(), false);
+            this.termAtt.setTermBuffer(unaccentedForm);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    /**
+     * @param word text with pointing
+     * @param unpointVowels true to indicate we also want to exclude vowels
+     * @return text without pointing
+     */
+    public static String unPoint(final String word, boolean unpointVowels) {
+        char endChar = unpointVowels ? ALEPH : SHEVA;
+
+        final StringBuilder sb = new StringBuilder(word);
+        int i = 0;
+        while (i < sb.length()) {
+            final char currentChar = sb.charAt(i);
+            //ignore characters outside of the Hebrew character set
+            if(currentChar < ETNAHTA || currentChar > ALEPH_LAMED) {
+                i++;
+            } else if (currentChar < endChar) {
+                sb.deleteCharAt(i);
+            } else if (currentChar >= HEBREW_COMBINED_RANGE_START && currentChar < ALEPH_LAMED) {
+                sb.setCharAt(i, (char) (currentChar - DAGESH_GAP));
+                i++;
+            } else {
+                i++;
+            }
+        }
+        return sb.toString();
+    }
+
+    private static final char SHEVA = 0x05B0;
+    private static final int ETNAHTA = 0x0591;
+    private static final int DAGESH_GAP = 0xFB44 - 0x05e3;
+    private static final int ALEPH = 0x05D0;
+    private static final char ALEPH_LAMED = 0xFB4F;
+    private static final char HEBREW_COMBINED_RANGE_START = 0xFB1D;
+}

--- a/src/main/resources/AnalyzerFactory.properties
+++ b/src/main/resources/AnalyzerFactory.properties
@@ -37,6 +37,7 @@ de.Analyzer=org.crosswire.jsword.index.lucene.analysis.GermanLuceneAnalyzer
 el.Analyzer=org.crosswire.jsword.index.lucene.analysis.GreekLuceneAnalyzer
 fa.Analyzer=org.crosswire.jsword.index.lucene.analysis.PersianLuceneAnalyzer
 grc.Analyzer=org.crosswire.jsword.index.lucene.analysis.GreekLuceneAnalyzer
+he.Analyzer=org.crosswire.jsword.index.lucene.analysis.HebrewLuceneAnalyzer
 ja.Analyzer=org.crosswire.jsword.index.lucene.analysis.SmartChineseLuceneAnalyzer
 zh.Analyzer=org.crosswire.jsword.index.lucene.analysis.SmartChineseLuceneAnalyzer
 th.Analyzer=org.crosswire.jsword.index.lucene.analysis.ThaiLuceneAnalyzer


### PR DESCRIPTION
Basically, this removes the cantillation from Hebrew indexed values.

As part of a bug fix, I've had to change the way JSword indexes Hebrew texts, to remove pointing from the indexed value).

I have not looked to integrate it to Sijo's latest code as that's a lot of work for STEP to upgrade all its other datasets. 

Let me know what you think of this and whether I should look to integrate it, or whether there is a better way going forward.

The key thing for STEP is to keep the Hebrew vowels and remove the cantillation. For STEP, this analyzer has to match a different non-JSword related analyzer.
