### PR TITLE
Correct TreeKey equals() by also comparing parents

### DIFF
--- a/src/main/java/org/crosswire/jsword/passage/TreeKey.java
+++ b/src/main/java/org/crosswire/jsword/passage/TreeKey.java
@@ -146,6 +146,36 @@ public class TreeKey extends AbstractKeyList {
         return parent;
     }
 
+    /** equality is tricky if comparing TreeKeys (as used by GenBooks) because some child keys can have the same name but different parents
+     */
+    @Override
+    public boolean equals(Object obj) {
+        // Since this can not be null
+        if (obj == null) {
+            return false;
+        }
+
+        // Check that that is the same as this
+        // Don't use instanceOf since that breaks inheritance
+        if (!obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+
+        TreeKey otherTreeKey = (TreeKey)obj;
+        if (!getName().equals(otherTreeKey.getName())) {
+            return false;
+        }
+
+        // names match so now work up the tree comparing parents
+
+        if (getParent()==null) {
+            return otherTreeKey.getParent()==null;
+        }
+        
+        // KeyTrees nodes can have the same name but different parents
+        return getParent().equals(otherTreeKey.getParent());
+    }
+    
     /* (non-Javadoc)
      * @see org.crosswire.jsword.passage.Key#blur(int, org.crosswire.jsword.passage.RestrictionType)
      */

--- a/src/test/java/org/crosswire/jsword/passage/AllTests.java
+++ b/src/test/java/org/crosswire/jsword/passage/AllTests.java
@@ -45,7 +45,8 @@ import org.junit.runners.Suite.SuiteClasses;
     PassageWriteSpeedTest.class,
     SimpleOsisIDParserTest.class,
     VerseTest.class,
-    VerseRangeTest.class
+    VerseRangeTest.class,
+    TreeKeyTest.class
 })
 public class AllTests {
 }

--- a/src/test/java/org/crosswire/jsword/passage/TreeKeyTest.java
+++ b/src/test/java/org/crosswire/jsword/passage/TreeKeyTest.java
@@ -1,0 +1,35 @@
+package org.crosswire.jsword.passage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TreeKeyTest {
+
+    private TreeKey pilgrimPart1;
+    private TreeKey pilgrimPart1FirstStage;
+    private TreeKey pilgrimPart1FirstStageClone = new TreeKey("First Stage", new TreeKey("Part 1"));
+    private TreeKey pilgrimPart2FirstStage;
+    
+    @Before
+    public void setUp() throws Exception {
+        pilgrimPart1 = new TreeKey("Part 1");
+        pilgrimPart1FirstStage = new TreeKey("First Stage", pilgrimPart1);
+        pilgrimPart1FirstStageClone = new TreeKey("First Stage", new TreeKey("Part 1"));
+        pilgrimPart2FirstStage = new TreeKey("First Stage", new TreeKey("Part 2"));
+    }
+
+    
+    @Test
+    public void testEquals() throws Exception {
+        
+        assertTrue(pilgrimPart1FirstStage.equals(pilgrimPart1FirstStageClone));
+        assertFalse(pilgrimPart1FirstStage.equals(pilgrimPart2FirstStage));
+        assertFalse(pilgrimPart1FirstStage.equals(null));
+        assertFalse(pilgrimPart1FirstStage.equals(pilgrimPart1));
+        assertTrue(pilgrimPart1FirstStage.getParent().equals(pilgrimPart1));
+    }
+
+}


### PR DESCRIPTION
TreeKey equals() method needs to take into account position of key in tree, not just name e.g. chapters with the same name might be in different sections of a book.