### PR TITLE
Strip versification tags from GBF modules

### DIFF
--- a/src/main/java/org/crosswire/jsword/book/filter/gbf/GBFTagBuilders.java
+++ b/src/main/java/org/crosswire/jsword/book/filter/gbf/GBFTagBuilders.java
@@ -74,6 +74,11 @@ public final class GBFTagBuilders {
      */
     public static Tag getTag(Book book, Key key, String name) {
         Tag tag = null;
+        if (name.startsWith("W") && (name.contains("-") || name.contains(":")) && name.matches("WT?[GH] ?[0-9]+[-:][0-9abc-]+")) {
+            // these tags show verse boundaries in different versification;
+            // ignore them instead of parsing them as Strongs / Morphology tags
+            return null;
+        }
         int length = name.length();
         if (length > 0) {
             // Only the first two letters of the tag are indicative of the tag


### PR DESCRIPTION
As a result, my 25 GBF modules only contain one single parse error in a
verse of FinPr92 - all others are gone.