### PR TITLE
Fix NPE in Language

### DIFF
--- a/src/main/java/org/crosswire/common/util/Language.java
+++ b/src/main/java/org/crosswire/common/util/Language.java
@@ -237,6 +237,9 @@ public class Language implements Comparable<Language> {
      */
     @Override
     public int hashCode() {
+        if (found==null) {
+            getName();
+        }
         return found.hashCode();
     }
 


### PR DESCRIPTION
Pulled JSword master for first time in 6 months and started getting this NPE.  I can't work out why I never had this NPE before because Language does not seem to have changed.  Maybe previously getName was always called early, but I can't see where.