### PR TITLE
Allow transient SwordBookMetaData properties

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -13,7 +13,7 @@
     <dependency org="org.apache.lucene"         name="lucene-smartcn"       rev="3.0.3"     conf="default->master,sources" />
     <dependency org="org.apache.lucene"         name="lucene-snowball"      rev="3.0.3"     conf="default->master,sources" />
     <dependency org="junit"                     name="junit"                rev="4.12"      conf="default->master,sources" />
-    <!-- dependency org="org.hamcrest"              name="hamcrest-library"     rev="1.3"/ -->
+    <dependency org="org.hamcrest"              name="hamcrest-all"     	rev="1.3"		conf="default->master,sources" />
     <dependency org="com.ibm.icu"               name="icu4j"                rev="54.1.1"    conf="default->master,sources" />
 	<dependency org="org.slf4j"                 name="slf4j-api"            rev="1.7.6"     conf="default->master,sources" />
 	<dependency org="org.slf4j"                 name="jcl-over-slf4j"       rev="1.7.6"     conf="default->master,sources" />

--- a/src/main/java/org/crosswire/common/util/CWProject.java
+++ b/src/main/java/org/crosswire/common/util/CWProject.java
@@ -75,6 +75,14 @@ public final class CWProject {
     }
 
     /**
+     * Required for reset of statics during testing
+     */
+    @SuppressWarnings("unused")
+    private static void reset() {
+        instance = new CWProject(); 
+    }
+    
+    /**
      * Establish how this project finds it's resources.
      * 
      * @param homeProperty

--- a/src/main/java/org/crosswire/jsword/book/sword/SwordBookMetaData.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/SwordBookMetaData.java
@@ -539,15 +539,45 @@ public final class SwordBookMetaData extends AbstractBookMetaData {
      * @see org.crosswire.jsword.book.BookMetaData#putProperty(java.lang.String, java.lang.String, boolean)
      */
     public void putProperty(String key, String value, boolean forFrontend) {
-        MetaDataLocator mdl = forFrontend ? SwordMetaDataLocator.FRONTEND : SwordMetaDataLocator.JSWORD;
-        IniSection config = forFrontend ? this.configFrontend : this.configJSword;
-        config.replace(key, value);
+        SwordMetaDataLocator mdl = forFrontend ? SwordMetaDataLocator.FRONTEND : SwordMetaDataLocator.JSWORD;
+        putProperty(key, value, mdl);
+    }
+
+    /**
+     * Allow specification of a specific SwordMetaDataLocator when saving a property.
+     * 
+     * @param key the entry that we are saving
+     * @param value the value of the entry
+     * @param metaDataLocator Place to save - front end storage, shared storage, or don't save(transient)
+     */
+    public void putProperty(String key, String value, SwordMetaDataLocator metaDataLocator) {
+        // allow fetch of this property for this session 
         configAll.replace(key, value);
-        try {
-            config.save(new File(mdl.getWriteLocation(), bookConf), getBookCharset());
-        } catch (IOException e1) {
-            // TODO Auto-generated catch block
-            e1.printStackTrace();
+        
+        // persist property for future sessions if JSword or Frontend metadatalocator
+        IniSection config;
+        switch (metaDataLocator) {
+        case FRONTEND:
+            config = this.configFrontend;
+            break;
+        case JSWORD:
+            config = this.configJSword;
+            break;
+        case TRANSIENT:
+        case SWORD:
+        default:
+            config = null;
+            break;
+        }
+
+        if (config!=null) {
+            config.replace(key, value);
+            try {
+                config.save(new File(metaDataLocator.getWriteLocation(), bookConf), getBookCharset());
+            } catch (IOException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/org/crosswire/jsword/book/sword/SwordMetaDataLocator.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/SwordMetaDataLocator.java
@@ -49,6 +49,16 @@ public enum SwordMetaDataLocator implements MetaDataLocator {
             return null;
         }
     },
+    TRANSIENT {
+        @Override
+        public File getReadLocation() {
+            return null;
+        }
+        @Override
+        public File getWriteLocation() {
+            return null;
+        }
+    },
     JSWORD {
         @Override
         public File getReadLocation() {

--- a/src/test/java/org/crosswire/jsword/book/sword/AllTests.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/AllTests.java
@@ -36,7 +36,7 @@ import org.junit.runners.Suite.SuiteClasses;
     ConfigEntryTableTest.class,
     RawFileBackendTest.class,
     SwordBookDriverTest.class,
-    //SwordBookMetaDataTest.class, // bad test
+    SwordBookMetaDataTest.class,
     SwordBookTest.class
 })
 public class AllTests {

--- a/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/BackendTest.java
@@ -308,7 +308,7 @@ public class BackendTest {
             return;
         }
 
-        Key key = currentBook.getKey("The Life of Flavius Josephus").get(5);
+        Key key = currentBook.getKey("The_Life_of_Flavius_Josephus").get(5);
         backendTest(currentBook, key, assertion);
     }
 

--- a/src/test/java/org/crosswire/jsword/book/sword/SwordBookMetaDataTest.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/SwordBookMetaDataTest.java
@@ -25,15 +25,18 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URISyntaxException;
 
+import org.crosswire.common.util.CWProject;
 import org.crosswire.common.util.IniSection;
-import org.crosswire.jsword.book.Book;
+import org.crosswire.jsword.book.BookException;
 import org.crosswire.jsword.book.BookMetaData;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * A Raw File format that allows for each verse to have it's own storage.
@@ -43,33 +46,37 @@ import org.mockito.Mockito;
  * @author DM Smith
  */
 public class SwordBookMetaDataTest {
-    Book mockBook;
     File configFile = new File("testconfig.conf");
     SwordBookMetaData swordBookMetaData = null;
 
+    @BeforeClass
+    public static void classSetup() throws Exception {
+    	// CWProject is a static that has probably already been initialised without a FrontEnd so forcefully reset it
+        Method resetMethod = CWProject.class.getDeclaredMethod("reset");
+        resetMethod.setAccessible(true);
+        resetMethod.invoke(CWProject.class);
+    }
+    
     @Before
     public void setUp() throws Exception {
-        String modName = "TestBook";
-        IniSection table = new IniSection(modName);
-        table.add(BookMetaData.KEY_LANG, "de");
-        table.add(SwordBookMetaData.KEY_DESCRIPTION, "MyNewBook");
-        table.add(SwordBookMetaData.KEY_MOD_DRV, "RawFiles");
-        table.add(SwordBookMetaData.KEY_ENCODING, "UTF-8");
-        try {
-            table.save(configFile, "UTF-8");
-        } catch (IOException e) {
-            System.out.println(e.getMessage());
-        }
-
-        swordBookMetaData = new SwordBookMetaData(configFile, new URI(""));
-        mockBook = Mockito.mock(Book.class);
-        mockBook.setBookMetaData(swordBookMetaData);
-        Mockito.when(mockBook.getBookMetaData()).thenReturn(swordBookMetaData);
+        // required for setting ui properties
+        CWProject.instance().setFrontendName("jsword-app");
+        
+        // ensure the ui property dir exists or an exception occurs
+        SwordMetaDataLocator.FRONTEND.getWriteLocation().mkdirs();
+        
+        swordBookMetaData = createTestSwordBookMetaData();
     }
 
     @After
     public void tearDown() throws Exception {
         configFile.delete();
+    }
+
+    @Test
+    public void testFrontEndSwordBookMetadataSetup() {
+        // From the code: "The write location supersedes the read location" so don't worry about getReadableFrontendProjectDir (which is null) 
+        assertNotNull(CWProject.instance().getWritableFrontendProjectDir());
     }
 
     @Test
@@ -81,4 +88,51 @@ public class SwordBookMetaDataTest {
         assertEquals("de", swordBookMetaData.getLanguage().getCode());
     }
 
+    @Test
+    public void testPutThenGetProperty() {
+        // simple jsword property
+        swordBookMetaData.putProperty("jswordkey", "jswordvalue");
+        assertEquals("jswordvalue", swordBookMetaData.getProperty("jswordkey"));
+
+        // UI property
+        swordBookMetaData.putProperty("uikey", "uivalue", true);
+        assertEquals("uivalue", swordBookMetaData.getProperty("uikey"));
+
+        // Transient property
+        swordBookMetaData.putProperty("transientkey", "transientvalue", SwordMetaDataLocator.TRANSIENT);
+        assertEquals("transientvalue", swordBookMetaData.getProperty("transientkey"));
+    }
+
+    @Test
+    public void testPropertyPersistence() throws Exception {
+        swordBookMetaData.putProperty("jswordkey", "jswordvalue");
+        swordBookMetaData.putProperty("uikey", "uivalue", true);
+        swordBookMetaData.putProperty("transientkey", "transientvalue", SwordMetaDataLocator.TRANSIENT);
+        
+        // jsword and ui properties should be persisted, and therefore restored into another SwordBookMetaData but not transient properties
+        SwordBookMetaData anotherSwordBookMetaData = createTestSwordBookMetaData();
+        
+        assertEquals("jswordvalue", anotherSwordBookMetaData.getProperty("jswordkey"));
+        assertEquals("uivalue", anotherSwordBookMetaData.getProperty("uikey"));
+        assertEquals(null, anotherSwordBookMetaData.getProperty("transientkey"));
+    }
+
+    private SwordBookMetaData createTestSwordBookMetaData() throws IOException, BookException, URISyntaxException {
+        String modName = "TestBook";
+        IniSection table = new IniSection(modName);
+        table.add(BookMetaData.KEY_LANG, "de");
+        table.add(SwordBookMetaData.KEY_DESCRIPTION, "MyNewBook");
+        table.add(SwordBookMetaData.KEY_MOD_DRV, "RawFiles");
+        table.add(SwordBookMetaData.KEY_DATA_PATH, "test");
+        table.add(SwordBookMetaData.KEY_ENCODING, "UTF-8");
+        try {
+            table.save(configFile, "UTF-8");
+        } catch (IOException e) {
+            System.out.println(e.getMessage());
+        }
+
+        swordBookMetaData = new SwordBookMetaData(configFile, new URI("file:///tmp"));
+        
+        return swordBookMetaData;
+    }
 }


### PR DESCRIPTION
I have made the smallest number of changes to allow And Bible to use transient SwordBook properties.  If you wish to refactor anything then I am happy to adjust And Bible.

The main change was adding a new SwordMetaDataLocator.TRANSIENT to signify properties should not be saved.  

To allow specification of TRANSIENT I added a new 
SwordBookMetaData.putProperty(String key, String value, SwordMetaDataLocator metaDataLocator)

but could not add this to the BookMetaData interface because generic BookMetaData does not know about SwordMetaDataLocator.  Maybe you would like to adjust this so it can be added to the interface.

I fixed and updated SwordBookMetaDataTest but don't like the code I added in the junit to reinitialise the static CWProject, can you think of a better alternative? 

I also fixed a bug in a BackendTest which may have been caused by a change to GenBook key structure.

