### PR TITLE
Changed path to a stylesheet distributed in the jsword repo.

### DIFF
--- a/src/main/java/org/crosswire/jsword/examples/APIExamples.java
+++ b/src/main/java/org/crosswire/jsword/examples/APIExamples.java
@@ -295,7 +295,7 @@ public class APIExamples {
         // The key's iterator would have iterated over verses.
 
         // The following shows how to use a stylesheet of your own choosing
-        String path = "xsl/cswing/simple.xsl";
+        String path = "org/crosswire/jsword/xml/html5.xsl";
         URL xslurl = ResourceUtil.getResource(path);
         // Make ranges  break  on  chapter
         Iterator<VerseRange> rangeIter = ((Passage) key).rangeIterator(RestrictionType.CHAPTER);


### PR DESCRIPTION
@dmsmith mentioned that he was trying to switch over to HTML5. Reflecting this change in the APIExamples.

The old path to simple.xsl does not exist in the jsword repo.