### PR TITLE
Fix errorprone book listing

### DIFF
--- a/src/main/java/org/crosswire/jsword/book/BookSet.java
+++ b/src/main/java/org/crosswire/jsword/book/BookSet.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.crosswire.common.util.Filter;
+import org.slf4j.Logger;
 
 /**
  * BookSet represents a collection of descriptions about Books which may be
@@ -137,6 +138,11 @@ public class BookSet extends ArrayList<Book> implements Set<Book> {
         // This can be revisited if the list performs badly.
         boolean added = false;
         for (Book book : c) {
+            try {
+                book.toString();
+            } catch (NullPointerException e) {
+                continue;
+            }
             if (add(book)) {
                 added = true;
             }

--- a/src/main/java/org/crosswire/jsword/book/BookSet.java
+++ b/src/main/java/org/crosswire/jsword/book/BookSet.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.crosswire.common.util.Filter;
-import org.slf4j.Logger;
 
 /**
  * BookSet represents a collection of descriptions about Books which may be


### PR DESCRIPTION
To prevent this from happening again:

http://www.crosswire.org/pipermail/sword-devel/2018-November/046078.html

Better ideas are welcome, but I believe this quick fix should make this less errorprone.