### PR TITLE
Correct duplication of field name in condition.

### DIFF
--- a/src/main/java/org/crosswire/jsword/book/sword/state/RawFileBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/RawFileBackendState.java
@@ -66,7 +66,7 @@ public class RawFileBackendState extends RawBackendState {
         if (existsAndCanReadAndWrite(otTextFile)
                 && existsAndCanReadAndWrite(ntTextFile)
                 && existsAndCanReadAndWrite(otIdxFile)
-                && existsAndCanReadAndWrite(otTextFile)
+                && existsAndCanReadAndWrite(ntIdxFile)
                 && (incFile == null || existsAndCanReadAndWrite(incFile)))
         {
             return true;


### PR DESCRIPTION
It appears that because of cut-n-paste the wrong field was used in the last condition.  The field `otTextFile` was specified twice and `ntIdxFile` was not used.