### PR TITLE
Fix misordered assertEquals() arguments

### DIFF
--- a/src/test/java/org/crosswire/jsword/book/SentenceUtilTest.java
+++ b/src/test/java/org/crosswire/jsword/book/SentenceUtilTest.java
@@ -55,7 +55,7 @@ public class SentenceUtilTest {
         Assert.assertEquals("three ", sa[2]);
 
         sa = SentenceUtil.tokenize("-one--two three ");
-        Assert.assertEquals(sa.length, 3);
+        Assert.assertEquals(3, sa.length);
         Assert.assertEquals("-one--", sa[0]);
         Assert.assertEquals("two ", sa[1]);
         Assert.assertEquals("three ", sa[2]);

--- a/src/test/java/org/crosswire/jsword/book/sword/ConfigEntryTableTest.java
+++ b/src/test/java/org/crosswire/jsword/book/sword/ConfigEntryTableTest.java
@@ -104,7 +104,7 @@ public class ConfigEntryTableTest {
         table.add(BookMetaData.KEY_LANG, "de");
         String lang = table.get(BookMetaData.KEY_LANG);
         Assert.assertNotNull(lang);
-        Assert.assertEquals(lang, "de");
+        Assert.assertEquals("de", lang);
 
         File configFile = new File("testconfig.conf");
         try {

--- a/src/test/java/org/crosswire/jsword/passage/PassageParentTst.java
+++ b/src/test/java/org/crosswire/jsword/passage/PassageParentTst.java
@@ -566,16 +566,16 @@ public class PassageParentTst {
 
     @Test
     public void testWriteCountVerses() {
-        Assert.assertEquals(genC1V135r.countVerses(), 3);
-        Assert.assertEquals(exoC2V1To10C2V1To11r.countVerses(), 21);
-        Assert.assertEquals(empty.countVerses(), 0);
+        Assert.assertEquals(3, genC1V135r.countVerses());
+        Assert.assertEquals(21, exoC2V1To10C2V1To11r.countVerses());
+        Assert.assertEquals(0, empty.countVerses());
     }
 
     @Test
     public void testWriteCountRanges() {
-        Assert.assertEquals(genC1V135r.countRanges(RestrictionType.NONE), 3);
-        Assert.assertEquals(exoC2V1To10C2V1To11r.countRanges(RestrictionType.NONE), 2);
-        Assert.assertEquals(empty.countVerses(), 0);
+        Assert.assertEquals(3, genC1V135r.countRanges(RestrictionType.NONE));
+        Assert.assertEquals(2, exoC2V1To10C2V1To11r.countRanges(RestrictionType.NONE));
+        Assert.assertEquals(0, empty.countVerses());
     }
 
     @Test
@@ -600,8 +600,8 @@ public class PassageParentTst {
 
     @Test
     public void testWriteBooksInPassage() {
-        Assert.assertEquals(genC1V135r.booksInPassage(), 1);
-        Assert.assertEquals(exoC2V1To10C2V1To11r.booksInPassage(), 1);
+        Assert.assertEquals(1, genC1V135r.booksInPassage());
+        Assert.assertEquals(1, exoC2V1To10C2V1To11r.booksInPassage());
     }
 
     @Test
@@ -664,63 +664,63 @@ public class PassageParentTst {
     public void testWriteAdd() throws Exception {
         temp = (Passage) genC1V135r.clone();
         temp.add(VerseFactory.fromString(v11n, "Gen 1:2"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-3, 5");
+        Assert.assertEquals("Gen 1:1-3, 5", temp.getName());
         temp.add(VerseFactory.fromString(v11n, "Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-5");
+        Assert.assertEquals("Gen 1:1-5", temp.getName());
         temp = (Passage) genC1V135r.clone();
         temp.add(VerseRangeFactory.fromString(v11n, "Gen 1:2-4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-5");
+        Assert.assertEquals("Gen 1:1-5", temp.getName());
         temp = (Passage) genC1V135r.clone();
         temp.add(VerseRangeFactory.fromString(v11n, "Gen 1:2"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-3, 5");
+        Assert.assertEquals("Gen 1:1-3, 5", temp.getName());
         temp.add(VerseRangeFactory.fromString(v11n, "Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-5");
+        Assert.assertEquals("Gen 1:1-5", temp.getName());
         temp = (Passage) genC1V135r.clone();
         temp.add(VerseRangeFactory.fromString(v11n, "Gen 1:1-5"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-5");
+        Assert.assertEquals("Gen 1:1-5", temp.getName());
     }
 
     @Test
     public void testWriteAddAll() throws Exception {
         temp = (Passage) genC1V135r.clone();
         temp.addAll(keyf.getKey(v11n, "Gen 1:2, Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-5");
+        Assert.assertEquals("Gen 1:1-5", temp.getName());
     }
 
     @Test
     public void testWriteClear() {
         temp = (Passage) genC1V135r.clone();
         temp.clear();
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
         temp.clear();
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
     }
 
     @Test
     public void testWriteRemove() throws Exception {
         temp = (Passage) genC1V135r.clone();
         temp.remove(VerseFactory.fromString(v11n, "Gen 1:3"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1, 5");
+        Assert.assertEquals("Gen 1:1, 5", temp.getName());
         temp.remove(VerseFactory.fromString(v11n, "Gen 1:5"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1");
+        Assert.assertEquals("Gen 1:1", temp.getName());
         temp.remove(VerseFactory.fromString(v11n, "Gen 1:1"));
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
         temp = keyf.getKey(v11n, "Gen 1:1-5");
         temp.remove(VerseFactory.fromString(v11n, "Gen 1:3"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1-2, 4-5");
+        Assert.assertEquals("Gen 1:1-2, 4-5", temp.getName());
     }
 
     @Test
     public void testWriteRemoveAllCollection() throws Exception {
         temp = keyf.getKey(v11n, "Gen 1:1-5");
         temp.removeAll(keyf.getKey(v11n, "Gen 1:2, Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1, 3, 5");
+        Assert.assertEquals("Gen 1:1, 3, 5", temp.getName());
         temp.removeAll(keyf.getKey(v11n, "Exo 1:2, Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1, 3, 5");
+        Assert.assertEquals("Gen 1:1, 3, 5", temp.getName());
         temp.removeAll(keyf.getKey(v11n, "Gen 1:2-Rev 22:21"));
-        Assert.assertEquals(temp.getName(), "Gen 1:1");
+        Assert.assertEquals("Gen 1:1", temp.getName());
         temp.removeAll(keyf.getKey(v11n, "Gen 1:1"));
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
     }
 
     @Ignore
@@ -728,24 +728,24 @@ public class PassageParentTst {
     public void testWriteRetainAllCollection() throws Exception {
         temp = keyf.getKey(v11n, "Gen 1:1-5");
         temp.retainAll(keyf.getKey(v11n, "Gen 1:2, Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:2, 4");
+        Assert.assertEquals("Gen 1:2, 4", temp.getName());
         temp.retainAll(keyf.getKey(v11n, "Exo 1:2, Gen 1:4"));
-        Assert.assertEquals(temp.getName(), "Gen 1:4");
+        Assert.assertEquals("Gen 1:4", temp.getName());
         temp.retainAll(keyf.getKey(v11n, "Gen 1:2-Rev 22:21"));
-        Assert.assertEquals(temp.getName(), "Gen 1:4");
+        Assert.assertEquals("Gen 1:4", temp.getName());
         temp.retainAll(keyf.getKey(v11n, "Gen 1:1"));
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
 
         temp.addAll(grace);
         Assert.assertEquals(temp.countVerses(), grace.countVerses());
         temp.retainAll(genToRev);
         Assert.assertEquals(temp, grace);
         temp.retainAll(keyf.getKey(v11n, "gen"));
-        Assert.assertEquals(temp.countVerses(), 10);
+        Assert.assertEquals(10, temp.countVerses());
         temp.retainAll(keyf.getKey(v11n, "gen 35:1-rev"));
-        Assert.assertEquals(temp.countVerses(), 4);
+        Assert.assertEquals(4, temp.countVerses());
         temp.retainAll(keyf.getKey(v11n, "exo-rev"));
-        Assert.assertEquals(temp.getName(), "");
+        Assert.assertEquals("", temp.getName());
     }
 
     @Test

--- a/src/test/java/org/crosswire/jsword/passage/PassageTally2Test.java
+++ b/src/test/java/org/crosswire/jsword/passage/PassageTally2Test.java
@@ -217,8 +217,8 @@ public class PassageTally2Test {
 
     @Test
     public void testCountVerses() {
-        Assert.assertEquals(tally.countVerses(), 6);
-        Assert.assertEquals(empty.countVerses(), 0);
+        Assert.assertEquals(6, tally.countVerses());
+        Assert.assertEquals(0, empty.countVerses());
     }
 
     @Test
@@ -305,7 +305,7 @@ public class PassageTally2Test {
     public void testFlatten() {
         temp = tally.clone();
         temp.flatten();
-        Assert.assertEquals(temp.getName(), "Gen 1:1, 3, 5, 7, 2:1, 3:1");
+        Assert.assertEquals("Gen 1:1, 3, 5, 7, 2:1, 3:1", temp.getName());
     }
 
     @Test

--- a/src/test/java/org/crosswire/jsword/passage/PassageUtilTest.java
+++ b/src/test/java/org/crosswire/jsword/passage/PassageUtilTest.java
@@ -98,10 +98,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 0, 0, 0));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 0));
         Assert.assertEquals(1, index[0]);
 
@@ -112,10 +112,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 0, 0, 1));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 1));
         Assert.assertEquals(1, index[0]);
 
@@ -126,10 +126,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 0, 0, 255));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 255));
         Assert.assertEquals(1, index[0]);
 
@@ -140,10 +140,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(2, PassageKeyFactory.toBinary(buffer, 0, 0, 256));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 256));
         Assert.assertEquals(2, index[0]);
 
@@ -154,10 +154,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(2, PassageKeyFactory.toBinary(buffer, 0, 0, 65535));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 65535));
         Assert.assertEquals(2, index[0]);
 
@@ -168,10 +168,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(3, PassageKeyFactory.toBinary(buffer, 0, 0, 65536));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 65536));
         Assert.assertEquals(3, index[0]);
 
@@ -182,10 +182,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(3, PassageKeyFactory.toBinary(buffer, 0, 0, 16777215));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 16777215));
         Assert.assertEquals(3, index[0]);
 
@@ -196,10 +196,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(4, PassageKeyFactory.toBinary(buffer, 0, 0, 16777216));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 16777216));
         Assert.assertEquals(4, index[0]);
 
@@ -210,10 +210,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(4, PassageKeyFactory.toBinary(buffer, 0, 0, 2147483647));
-        Assert.assertEquals(buffer[0], 0);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(0, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(0, PassageKeyFactory.fromBinary(buffer, index, 2147483647));
         Assert.assertEquals(4, index[0]);
 
@@ -224,10 +224,10 @@ public class PassageUtilTest {
                 (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 0, 1, 1));
-        Assert.assertEquals(buffer[0], 1);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(1, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(1, PassageKeyFactory.fromBinary(buffer, index, 1));
         Assert.assertEquals(1, index[0]);
 
@@ -238,10 +238,10 @@ public class PassageUtilTest {
                 (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 0, 255, 255));
-        Assert.assertEquals(buffer[0], -1);
-        Assert.assertEquals(buffer[1], 0);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(-1, buffer[0]);
+        Assert.assertEquals(0, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(255, PassageKeyFactory.fromBinary(buffer, index, 255));
         Assert.assertEquals(1, index[0]);
 
@@ -252,10 +252,10 @@ public class PassageUtilTest {
                 (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         };
         Assert.assertEquals(2, PassageKeyFactory.toBinary(buffer, 0, 65535, 65535));
-        Assert.assertEquals(buffer[0], -1);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], 0);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(-1, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(0, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(65535, PassageKeyFactory.fromBinary(buffer, index, 65535));
         Assert.assertEquals(2, index[0]);
 
@@ -266,10 +266,10 @@ public class PassageUtilTest {
                 (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         };
         Assert.assertEquals(3, PassageKeyFactory.toBinary(buffer, 0, 16777215, 16777215));
-        Assert.assertEquals(buffer[0], -1);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], 0);
+        Assert.assertEquals(-1, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(0, buffer[3]);
         Assert.assertEquals(16777215, PassageKeyFactory.fromBinary(buffer, index, 16777215));
         Assert.assertEquals(3, index[0]);
 
@@ -280,10 +280,10 @@ public class PassageUtilTest {
                 (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         };
         Assert.assertEquals(4, PassageKeyFactory.toBinary(buffer, 0, 2147483647, 2147483647));
-        Assert.assertEquals(buffer[0], 127);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], -1);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(127, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(-1, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(2147483647, PassageKeyFactory.fromBinary(buffer, index, 2147483647));
         Assert.assertEquals(4, index[0]);
 
@@ -294,10 +294,10 @@ public class PassageUtilTest {
                 (byte) -1, (byte) -1, (byte) -1, (byte) -1,
         };
         Assert.assertEquals(1, PassageKeyFactory.toBinary(buffer, 2, 10, 11));
-        Assert.assertEquals(buffer[0], -1);
-        Assert.assertEquals(buffer[1], -1);
-        Assert.assertEquals(buffer[2], 10);
-        Assert.assertEquals(buffer[3], -1);
+        Assert.assertEquals(-1, buffer[0]);
+        Assert.assertEquals(-1, buffer[1]);
+        Assert.assertEquals(10, buffer[2]);
+        Assert.assertEquals(-1, buffer[3]);
         Assert.assertEquals(10, PassageKeyFactory.fromBinary(buffer, index, 11));
         Assert.assertEquals(3, index[0]);
 

--- a/src/test/java/org/crosswire/jsword/passage/VerseTest.java
+++ b/src/test/java/org/crosswire/jsword/passage/VerseTest.java
@@ -91,7 +91,7 @@ public class VerseTest {
    @Test
     public void testNewViaString() throws Exception {
        Assert.assertEquals(gen11s, VerseFactory.fromString(v11n, "Gen.1.1!sub"));
-        Assert.assertEquals(gen11, Verse.DEFAULT);
+        Assert.assertEquals(Verse.DEFAULT, gen11);
         Assert.assertEquals(gen11, VerseFactory.fromString(v11n, "Genesis 1 1"));
         Assert.assertEquals(gen11, VerseFactory.fromString(v11n, "Gen 1 1"));
         Assert.assertEquals(gen11, VerseFactory.fromString(v11n, "Ge 1 1"));
@@ -194,24 +194,24 @@ public class VerseTest {
 
     @Test
     public void testGetName() throws Exception {
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Genesis 1 1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 1 1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Genesis 1:1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 1 1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "ge 1 1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "ge").getName(), "Gen 0:0");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Ge:1:1").getName(), "Gen 1:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Jude 1").getName(), "Jude 1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Jude").getName(), "Jude 0");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Jude 1:1").getName(), "Jude 1");
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "Genesis 1 1").getName());
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "Gen 1 1").getName());
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "Genesis 1:1").getName());
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "Gen 1 1").getName());
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "ge 1 1").getName());
+        Assert.assertEquals("Gen 0:0", VerseFactory.fromString(v11n, "ge").getName());
+        Assert.assertEquals("Gen 1:1", VerseFactory.fromString(v11n, "Ge:1:1").getName());
+        Assert.assertEquals("Jude 1", VerseFactory.fromString(v11n, "Jude 1").getName());
+        Assert.assertEquals("Jude 0", VerseFactory.fromString(v11n, "Jude").getName());
+        Assert.assertEquals("Jude 1", VerseFactory.fromString(v11n, "Jude 1:1").getName());
     }
 
     @Test
     public void testGetNameVerse() throws Exception {
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 1:2").getName(gen11), "2");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 2:1").getName(gen11), "2:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 2:1").getName(jude9), "Gen 2:1");
-        Assert.assertEquals(VerseFactory.fromString(v11n, "Gen 2:1").getName(null), "Gen 2:1");
+        Assert.assertEquals("2", VerseFactory.fromString(v11n, "Gen 1:2").getName(gen11));
+        Assert.assertEquals("2:1", VerseFactory.fromString(v11n, "Gen 2:1").getName(gen11));
+        Assert.assertEquals("Gen 2:1", VerseFactory.fromString(v11n, "Gen 2:1").getName(jude9));
+        Assert.assertEquals("Gen 2:1", VerseFactory.fromString(v11n, "Gen 2:1").getName(null));
     }
 
     @Test
@@ -255,14 +255,14 @@ public class VerseTest {
     public void testCompareTo() {
         Assert.assertTrue(gen11.compareTo(rev99) < 0);
         Assert.assertTrue(rev99.compareTo(gen11) > 0);
-        Assert.assertEquals(gen11.compareTo(gen11), 0);
+        Assert.assertEquals(0, gen11.compareTo(gen11));
     }
 
     @Test
     public void testAddSubtract() {
-        Assert.assertEquals(v11n.distance(gen11, gen12), 1);
-        Assert.assertEquals(v11n.distance(gen11, gen11), 0);
-        Assert.assertEquals(v11n.distance(gen12, gen11), -1);
+        Assert.assertEquals(1, v11n.distance(gen11, gen12));
+        Assert.assertEquals(0, v11n.distance(gen11, gen11));
+        Assert.assertEquals(-1, v11n.distance(gen12, gen11));
         Verse last = gen11.clone();
         for (int i = 0; i < v11n.maximumOrdinal(); i += 99) {
             Verse next = v11n.add(last, i);
@@ -295,41 +295,41 @@ public class VerseTest {
 
     @Test
     public void testGetBook() {
-        Assert.assertEquals(gen11.getBook(), BibleBook.GEN);
-        Assert.assertEquals(gen12.getBook(), BibleBook.GEN);
-        Assert.assertEquals(gen21.getBook(), BibleBook.GEN);
-        Assert.assertEquals(gen22.getBook(), BibleBook.GEN);
-        Assert.assertEquals(rev11.getBook(), BibleBook.REV);
-        Assert.assertEquals(rev12.getBook(), BibleBook.REV);
-        Assert.assertEquals(rev21.getBook(), BibleBook.REV);
-        Assert.assertEquals(rev22.getBook(), BibleBook.REV);
-        Assert.assertEquals(rev99.getBook(), BibleBook.REV);
+        Assert.assertEquals(BibleBook.GEN, gen11.getBook());
+        Assert.assertEquals(BibleBook.GEN, gen12.getBook());
+        Assert.assertEquals(BibleBook.GEN, gen21.getBook());
+        Assert.assertEquals(BibleBook.GEN, gen22.getBook());
+        Assert.assertEquals(BibleBook.REV, rev11.getBook());
+        Assert.assertEquals(BibleBook.REV, rev12.getBook());
+        Assert.assertEquals(BibleBook.REV, rev21.getBook());
+        Assert.assertEquals(BibleBook.REV, rev22.getBook());
+        Assert.assertEquals(BibleBook.REV, rev99.getBook());
     }
 
     @Test
     public void testGetChapter() {
-        Assert.assertEquals(gen11.getChapter(), 1);
-        Assert.assertEquals(gen12.getChapter(), 1);
-        Assert.assertEquals(gen21.getChapter(), 2);
-        Assert.assertEquals(gen22.getChapter(), 2);
-        Assert.assertEquals(rev11.getChapter(), 1);
-        Assert.assertEquals(rev12.getChapter(), 1);
-        Assert.assertEquals(rev21.getChapter(), 2);
-        Assert.assertEquals(rev22.getChapter(), 2);
-        Assert.assertEquals(rev99.getChapter(), 22);
+        Assert.assertEquals(1, gen11.getChapter());
+        Assert.assertEquals(1, gen12.getChapter());
+        Assert.assertEquals(2, gen21.getChapter());
+        Assert.assertEquals(2, gen22.getChapter());
+        Assert.assertEquals(1, rev11.getChapter());
+        Assert.assertEquals(1, rev12.getChapter());
+        Assert.assertEquals(2, rev21.getChapter());
+        Assert.assertEquals(2, rev22.getChapter());
+        Assert.assertEquals(22, rev99.getChapter());
     }
 
     @Test
     public void testGetVerse() {
-        Assert.assertEquals(gen11.getVerse(), 1);
-        Assert.assertEquals(gen12.getVerse(), 2);
-        Assert.assertEquals(gen21.getVerse(), 1);
-        Assert.assertEquals(gen22.getVerse(), 2);
-        Assert.assertEquals(rev11.getVerse(), 1);
-        Assert.assertEquals(rev12.getVerse(), 2);
-        Assert.assertEquals(rev21.getVerse(), 1);
-        Assert.assertEquals(rev22.getVerse(), 2);
-        Assert.assertEquals(rev99.getVerse(), 21);
+        Assert.assertEquals(1, gen11.getVerse());
+        Assert.assertEquals(2, gen12.getVerse());
+        Assert.assertEquals(1, gen21.getVerse());
+        Assert.assertEquals(2, gen22.getVerse());
+        Assert.assertEquals(1, rev11.getVerse());
+        Assert.assertEquals(2, rev12.getVerse());
+        Assert.assertEquals(1, rev21.getVerse());
+        Assert.assertEquals(2, rev22.getVerse());
+        Assert.assertEquals(21, rev99.getVerse());
     }
 
     @Test
@@ -348,13 +348,13 @@ public class VerseTest {
     @Test
     public void testGetAccuracy() throws Exception {
         VerseRange vr = new VerseRange(v11n, gen11, gen11);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "Gen 1:1", AccuracyType.tokenize("Gen 1:1"), vr), AccuracyType.BOOK_VERSE);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "Gen 1", AccuracyType.tokenize("Gen 1"), vr), AccuracyType.BOOK_CHAPTER);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "Jude 1", AccuracyType.tokenize("Jude 1"), vr), AccuracyType.BOOK_VERSE);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "Jude 1:1", AccuracyType.tokenize("Jude 1:1"), vr), AccuracyType.BOOK_VERSE);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "Gen", AccuracyType.tokenize("Gen"), vr), AccuracyType.BOOK_ONLY);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "1:1", AccuracyType.tokenize("1:1"), vr), AccuracyType.CHAPTER_VERSE);
-        Assert.assertEquals(AccuracyType.fromText(v11n, "1", AccuracyType.tokenize("1"), vr), AccuracyType.VERSE_ONLY);
+        Assert.assertEquals(AccuracyType.BOOK_VERSE, AccuracyType.fromText(v11n, "Gen 1:1", AccuracyType.tokenize("Gen 1:1"), vr));
+        Assert.assertEquals(AccuracyType.BOOK_CHAPTER, AccuracyType.fromText(v11n, "Gen 1", AccuracyType.tokenize("Gen 1"), vr));
+        Assert.assertEquals(AccuracyType.BOOK_VERSE, AccuracyType.fromText(v11n, "Jude 1", AccuracyType.tokenize("Jude 1"), vr));
+        Assert.assertEquals(AccuracyType.BOOK_VERSE, AccuracyType.fromText(v11n, "Jude 1:1", AccuracyType.tokenize("Jude 1:1"), vr));
+        Assert.assertEquals(AccuracyType.BOOK_ONLY, AccuracyType.fromText(v11n, "Gen", AccuracyType.tokenize("Gen"), vr));
+        Assert.assertEquals(AccuracyType.CHAPTER_VERSE, AccuracyType.fromText(v11n, "1:1", AccuracyType.tokenize("1:1"), vr));
+        Assert.assertEquals(AccuracyType.VERSE_ONLY, AccuracyType.fromText(v11n, "1", AccuracyType.tokenize("1"), vr));
         try {
             AccuracyType.fromText(v11n, "Komplete and utter rubbish", AccuracyType.tokenize("Komplete and utter rubbish"), vr);
             Assert.fail();
@@ -438,7 +438,7 @@ public class VerseTest {
 
     @Test
     public void testToVerseArray() {
-        Assert.assertEquals(gen11.toVerseArray().length, 1);
+        Assert.assertEquals(1, gen11.toVerseArray().length);
     }
 
     @Test


### PR DESCRIPTION
The constant expected value should be the first argument.