### PR TITLE
Use parameterized log messages instead of concatenation.

### DIFF
--- a/src/main/java/org/crosswire/common/util/NetUtil.java
+++ b/src/main/java/org/crosswire/common/util/NetUtil.java
@@ -498,7 +498,7 @@ public final class NetUtil {
             // JNLP or other systems that can't use file: URIs. But it is silly
             // to get to picky so if there is a solution using file: then just
             // print a warning and carry on.
-            LOGGER.warn("index file for " + uri.toString() + " was not found.");
+            LOGGER.warn("index file for {} was not found.", uri.toString());
             if (uri.getScheme().equals(PROTOCOL_FILE)) {
                 return listByFile(uri, filter);
             }

--- a/src/main/java/org/crosswire/jsword/examples/GatherAllReferences.java
+++ b/src/main/java/org/crosswire/jsword/examples/GatherAllReferences.java
@@ -98,7 +98,7 @@ public final class GatherAllReferences {
             }
             readKey(book, key, stats);
         }
-        log.warn(book.getInitials() + ':' + stats[0] + ':' + stats[1]);
+        log.warn("{}:{}:{}", book.getInitials(), stats[0], stats[1]);
 
     }
 

--- a/src/main/java/org/crosswire/jsword/index/lucene/InstalledIndex.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/InstalledIndex.java
@@ -129,7 +129,7 @@ public final class InstalledIndex {
             }
 
         } catch (IOException e) {
-            log.error("Property file read error: " + propURI.toString(), e);
+            log.error("Property file read error: {}", propURI.toString(), e);
         }
     }
 


### PR DESCRIPTION
More efficient and less memory than concatenation.