### PR TITLE
Chore: fix Logger instances initialization

### DIFF
--- a/src/main/java/org/crosswire/common/util/Languages.java
+++ b/src/main/java/org/crosswire/common/util/Languages.java
@@ -207,5 +207,5 @@ public final class Languages {
     /**
      * The log stream
      */
-    protected static final Logger log = LoggerFactory.getLogger(Books.class);
+    protected static final Logger log = LoggerFactory.getLogger(Languages.class);
 }

--- a/src/main/java/org/crosswire/jsword/book/sword/state/RawLDBackendState.java
+++ b/src/main/java/org/crosswire/jsword/book/sword/state/RawLDBackendState.java
@@ -178,5 +178,5 @@ public class RawLDBackendState extends AbstractOpenFileState  {
     /**
      * The log stream
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(RawLDBackend.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RawLDBackendState.class);
 }


### PR DESCRIPTION
Chore: fix logger instances that are initialized with a class literal from a different class than the Logger is contained in.