### PR TITLE
Chore: remove local variable that is never queried

### DIFF
--- a/src/main/java/org/crosswire/common/util/Ini.java
+++ b/src/main/java/org/crosswire/common/util/Ini.java
@@ -489,10 +489,7 @@ final class Ini {
             }
 
             String sectionName = "";
-            StringBuilder buf = new StringBuilder();
             while (true) {
-                // Empty out the buffer
-                buf.setLength(0);
                 String line = advance(bin);
                 if (line == null) {
                     break;


### PR DESCRIPTION
`StringBuilder buf` variable is defined, set once, and then never used.