### PR TITLE
Chore: replace wildcard imports with list of all classes

### DIFF
--- a/src/main/java/org/crosswire/jsword/examples/APIExamples.java
+++ b/src/main/java/org/crosswire/jsword/examples/APIExamples.java
@@ -25,21 +25,37 @@ import org.crosswire.common.xml.Converter;
 import org.crosswire.common.xml.SAXEventProvider;
 import org.crosswire.common.xml.TransformingSAXEventProvider;
 import org.crosswire.common.xml.XMLUtil;
-import org.crosswire.jsword.book.*;
+import org.crosswire.jsword.book.Book;
+import org.crosswire.jsword.book.BookCategory;
+import org.crosswire.jsword.book.BookData;
+import org.crosswire.jsword.book.BookException;
+import org.crosswire.jsword.book.BookFilter;
+import org.crosswire.jsword.book.BookFilters;
+import org.crosswire.jsword.book.BookMetaData;
+import org.crosswire.jsword.book.Books;
+import org.crosswire.jsword.book.BooksEvent;
+import org.crosswire.jsword.book.BooksListener;
+import org.crosswire.jsword.book.OSISUtil;
 import org.crosswire.jsword.book.install.InstallException;
 import org.crosswire.jsword.book.install.InstallManager;
 import org.crosswire.jsword.book.install.Installer;
 import org.crosswire.jsword.index.search.DefaultSearchModifier;
 import org.crosswire.jsword.index.search.DefaultSearchRequest;
-import org.crosswire.jsword.passage.*;
+import org.crosswire.jsword.passage.Key;
+import org.crosswire.jsword.passage.NoSuchKeyException;
+import org.crosswire.jsword.passage.Passage;
+import org.crosswire.jsword.passage.PassageTally;
+import org.crosswire.jsword.passage.RestrictionType;
+import org.crosswire.jsword.passage.VerseRange;
 import org.crosswire.jsword.util.ConverterFactory;
 import org.xml.sax.SAXException;
 
-import javax.xml.transform.TransformerException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.transform.TransformerException;
 
 /**
  * All the methods in this class highlight some are of the API and how to use

--- a/src/main/java/org/crosswire/jsword/index/lucene/InstalledIndex.java
+++ b/src/main/java/org/crosswire/jsword/index/lucene/InstalledIndex.java
@@ -19,7 +19,10 @@
  */
 package org.crosswire.jsword.index.lucene;
 
-import org.crosswire.common.util.*;
+import org.crosswire.common.util.CWProject;
+import org.crosswire.common.util.FileUtil;
+import org.crosswire.common.util.NetUtil;
+import org.crosswire.common.util.PropertyMap;
 import org.crosswire.jsword.book.Book;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/org/crosswire/jsword/bridge/DwrBridgeMissingAssetsTest.java
+++ b/src/test/java/org/crosswire/jsword/bridge/DwrBridgeMissingAssetsTest.java
@@ -22,7 +22,11 @@ package org.crosswire.jsword.bridge;
 import org.crosswire.jsword.book.BookException;
 import org.crosswire.jsword.passage.NoSuchKeyException;
 import org.crosswire.jsword.versification.BookName;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Test of functionality for use with DWR. This test assumes, at a minimum, that

--- a/src/test/java/org/crosswire/jsword/versification/VersificationsMapperTest.java
+++ b/src/test/java/org/crosswire/jsword/versification/VersificationsMapperTest.java
@@ -27,7 +27,11 @@ import org.crosswire.jsword.passage.Passage;
 import org.crosswire.jsword.passage.PassageKeyFactory;
 import org.crosswire.jsword.passage.Verse;
 import org.crosswire.jsword.passage.VerseFactory;
-import org.crosswire.jsword.versification.system.*;
+import org.crosswire.jsword.versification.system.SystemCatholic;
+import org.crosswire.jsword.versification.system.SystemCatholic2;
+import org.crosswire.jsword.versification.system.SystemKJVA;
+import org.crosswire.jsword.versification.system.SystemSynodal;
+import org.crosswire.jsword.versification.system.Versifications;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
It appears from reading the checkstyle files that avoiding wildcard imports is the preference for the project.

BTW,  is there a preferred ordering of imports?  Alphabetic order?  Static imports first?  Crosswire classes first?  Something else?